### PR TITLE
Should HandlerLoader load the same assembly multiple times?

### DIFF
--- a/src/Rebus.Tests/Configuration/TestDiscoveryConfigurer.cs
+++ b/src/Rebus.Tests/Configuration/TestDiscoveryConfigurer.cs
@@ -30,7 +30,21 @@ namespace Rebus.Tests.Configuration
             // assert
             containerAdapter.AssertWasCalled(c => c.Register(typeof (ThisClassNameIsPrettyRecognizable),
                                                              Lifestyle.Instance,
-                                                             typeof (IHandleMessages<string>)));
+                                                             typeof (IHandleMessages<string>)), options => options.Repeat.Once());
+        }
+
+        [Test]
+        public void SameAssemblyIsOnlyLoadedOnce()
+        {
+            // arrange
+
+            // act
+            configurer.Handlers.LoadFrom(Assembly.GetExecutingAssembly(), Assembly.GetExecutingAssembly());
+            
+            // assert
+            containerAdapter.AssertWasCalled(c => c.Register(typeof(ThisClassNameIsPrettyRecognizable),
+                                                             Lifestyle.Instance,
+                                                             typeof(IHandleMessages<string>)), options => options.Repeat.Once());
         }
 
         [Test]

--- a/src/Rebus/Configuration/Configurers/HandlerLoader.cs
+++ b/src/Rebus/Configuration/Configurers/HandlerLoader.cs
@@ -25,7 +25,7 @@ namespace Rebus.Configuration.Configurers
         {
             Log.Debug("Loading handlers");
 
-            var assembliesToScan = new[] { assemblyToScan }.Concat(additionalAssemblies);
+            var assembliesToScan = new[] { assemblyToScan }.Union(additionalAssemblies);
 
             foreach(var assembly in assembliesToScan)
             {


### PR DESCRIPTION
Hi Mogens,

When looking through the code I noticed that you called .Concat when combining the assemblyToScan with additional assemblies, I thought that was strange since that means that if a user of HandlerLoader accidently specifies the same assembly twice that assembly will have its IHandleMessages implementing classes registered twice in the IoC, which depending on the IoC being used might cause an exception. 

I changed the .Concat to a .Union and added and tweaked the unit tests covering this in order to test the change in behavior.

If there's something I missed and there's a good reason why you used .Concat please explain :-)

Best Regards

Your fellow d60'er

Simon
