### PR TITLE
Internalizing JSON.NET in ILMerge.

### DIFF
--- a/scripts/build.proj
+++ b/scripts/build.proj
@@ -48,7 +48,7 @@
     
     <Delete Files="$(BuildOutputFolder)\Rebus.dll"/>
     <!-- should probably use variables instead of hardcoded DLL paths here ... -->
-    <Exec Command="$(IlMerge) /out:$(BuildOutputFolder)\Rebus.dll ..\src\Rebus\bin\Release\Rebus.dll ..\src\Rebus\bin\Release\Newtonsoft.Json.dll /targetplatform:v4"/>
+    <Exec Command="$(IlMerge) /out:$(BuildOutputFolder)\Rebus.dll ..\src\Rebus\bin\Release\Rebus.dll ..\src\Rebus\bin\Release\Newtonsoft.Json.dll /targetplatform:v4 /internalize"/>
   </Target>
   
   <Target Name="createNugetPackage">


### PR DESCRIPTION
Added /internalize option to ILMerge to avoid JSON.NET being publicly visible in the Rebus assembly.
