### PR TITLE
Small change to Snoop to avoid the use of magic-strings for propertynames

### DIFF
--- a/src/Rebus.Snoop/ViewModel/MachinesViewModel.cs
+++ b/src/Rebus.Snoop/ViewModel/MachinesViewModel.cs
@@ -151,7 +151,7 @@ namespace Rebus.Snoop.ViewModel
         public bool CanMoveMessagesToSourceQueue
         {
             get { return canMoveMessagesToSourceQueue; }
-            set { SetValue("CanMoveMessagesToSourceQueue", value); }
+            set { SetValue( () => CanMoveMessagesToSourceQueue, value); }
         }
 
         public ObservableCollection<Machine> Machines

--- a/src/Rebus.Snoop/ViewModel/Models/Machine.cs
+++ b/src/Rebus.Snoop/ViewModel/Models/Machine.cs
@@ -21,7 +21,7 @@ namespace Rebus.Snoop.ViewModel.Models
         public string MachineName
         {
             get { return machineName; }
-            set { SetValue("MachineName", value); }
+            set { SetValue(() => MachineName, value); }
         }
 
         public ObservableCollection<Queue> Queues
@@ -32,7 +32,7 @@ namespace Rebus.Snoop.ViewModel.Models
         public bool Success
         {
             get { return success; }
-            set { SetValue("Success", value); }
+            set { SetValue( () => Success, value); }
         }
        
         public void SetQueues(IEnumerable<Queue> newQueues)

--- a/src/Rebus.Snoop/ViewModel/Models/Message.cs
+++ b/src/Rebus.Snoop/ViewModel/Models/Message.cs
@@ -17,13 +17,13 @@ namespace Rebus.Snoop.ViewModel.Models
         public string Body
         {
             get { return body; }
-            set { SetValue("Body", value); }
+            set { SetValue(() => Body, value); }
         }
 
         public Dictionary<string, string> Headers
         {
             get { return headers; }
-            set { SetValue("Headers", value, "HeadersExceptError", "ErrorDetails"); }
+            set { SetValue(() => Headers, value, ExtractPropertyName(() => HeadersExceptError), ExtractPropertyName(() => ErrorDetails)); }
         }
 
         public IEnumerable<KeyValuePair<string, string>> HeadersExceptError
@@ -34,31 +34,31 @@ namespace Rebus.Snoop.ViewModel.Models
         public string Label
         {
             get { return label; }
-            set { SetValue("Label", value); }
+            set { SetValue(() => Label, value); }
         }
 
         public int Bytes
         {
             get { return bytes; }
-            set { SetValue("Bytes", value); }
+            set { SetValue(() => Bytes, value); }
         }
 
         public DateTime Time
         {
             get { return time; }
-            set { SetValue("Time", value); }
+            set { SetValue(() => Time, value); }
         }
 
         public string Id
         {
             get { return id; }
-            set { SetValue("Id", value); }
+            set { SetValue(() => Id, value); }
         }
 
         public string QueuePath
         {
             get { return queuePath; }
-            set { SetValue("QueuePath", value); }
+            set { SetValue(() => QueuePath, value); }
         }
 
         public string ErrorDetails

--- a/src/Rebus.Snoop/ViewModel/Models/Queue.cs
+++ b/src/Rebus.Snoop/ViewModel/Models/Queue.cs
@@ -24,7 +24,7 @@ namespace Rebus.Snoop.ViewModel.Models
         public bool Initialized
         {
             get { return initialized; }
-            private set { SetValue("Initialized", value); }
+            private set { SetValue(() => Initialized, value); }
         }
 
         public Queue(MessageQueue queue)
@@ -38,19 +38,19 @@ namespace Rebus.Snoop.ViewModel.Models
         public string QueueName
         {
             get { return queueName; }
-            set { SetValue("QueueName", value); }
+            set { SetValue(() => QueueName, value); }
         }
 
         public string QueuePath
         {
             get { return queuePath; }
-            set { SetValue("QueuePath", value); }
+            set { SetValue(() => QueuePath, value); }
         }
 
         public int MessageCount
         {
             get { return messageCount; }
-            set { SetValue("MessageCount", value); }
+            set { SetValue(() => MessageCount, value); }
         }
 
         public ObservableCollection<Message> Messages


### PR DESCRIPTION
ExtractPropertyName method will use expression of func t to get the property name, this way when you select a property to send to SetValue you don't need to supply a string but can instead get type-safety. This is also awesome if you decide to rename that property.

Also, this is a couple of fun gists, but I thought it might be overkill to add it to Rebus, it's awesome though:

It uses a CIL reader from mono to get the backing field of a property from the cil, then you don't have to rely on your backingfields having a specific name that is exactly the same as the property except a lowercase first letter :)

https://gist.github.com/104006
https://gist.github.com/104001
