### PR TITLE
Fixed a minor bit regarding configuration

### DIFF
--- a/src/Rebus.Tests/Configuration/TestDetermineDestinationFromConfigurationSection.cs
+++ b/src/Rebus.Tests/Configuration/TestDetermineDestinationFromConfigurationSection.cs
@@ -62,6 +62,18 @@ namespace Rebus.Tests.Configuration
             // assert
             section.Workers.ShouldBe(5);
         }
+
+        [Test]
+        public void CanDetermineNumberOfWorkersFromExtensionMethod()
+        {
+            // arrange
+
+            // act
+            var workers = RebusConfigurationSection.GetConfigurationValueOrDefault(x => x.Workers, 0);
+
+            // assert
+            workers.ShouldBe(5);
+        }
     }
 
     class SomeMessageType

--- a/src/Rebus/Configuration/RebusConfigurationSection.cs
+++ b/src/Rebus/Configuration/RebusConfigurationSection.cs
@@ -89,10 +89,11 @@ that it is NOT possible to rename this section, even though the declaration make
             if (!(section is RebusConfigurationSection)) return defaultValue;
 
             var configurationValue = getConfigurationValue((RebusConfigurationSection)section);
+
             if (configurationValue == null) return defaultValue;
 
             var stringValue = configurationValue as string;
-            if (string.IsNullOrEmpty(stringValue)) return defaultValue;
+            if (configurationValue is string && string.IsNullOrEmpty(stringValue)) return defaultValue;
 
             return configurationValue;
         }


### PR DESCRIPTION
When calling Rebus/Configuration/RebusConfigurationSection.GetConfigurationValueOrDefault(Func<RebusConfigurationSection, TValue>, TValue) with something other than a string, it will always return the default value since the type check will fail.

Signed-off-by: kim kim@bosbec.se
