### PR TITLE
Git repo tagging of new version

### DIFF
--- a/push_packages.bat
+++ b/push_packages.bat
@@ -13,5 +13,9 @@ goto :DONE
 :GO
 %WINDIR%\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe scripts\build.proj /v:m /t:build;pushNugetPackages /p:Version=%VERSION%
 
+if %errorlevel% neq 0 goto :DONE
+git tag %VERSION%
+echo Tagged commit with tag '%VERSION%' - push tags to origin with 'git push --tags'.
+
 :DONE
 @prompt $p$g


### PR DESCRIPTION
Added git tagging to push_packages.bat when a new version is pushed to NuGet - for easier reference between NuGet packages and exact source.

Produces this:
https://github.com/rasmuskl/NScripto/tags
