### PR TITLE
Added support for collection initializer enabling more convenient syntax

### DIFF
--- a/src/Rebus.Tests/Testing/TestSagaFixture.cs
+++ b/src/Rebus.Tests/Testing/TestSagaFixture.cs
@@ -106,6 +106,16 @@ namespace Rebus.Tests.Testing
                 });
         }
 
+        [Test]
+        public void AddShouldAddToAvailableSagaData()
+        {
+            var someSagaData = new SomeSagaData { JustSomeText = Guid.NewGuid().ToString()};
+            
+            var fixture = new SagaFixture<SomeSagaData>(new SomeSaga()) {someSagaData};
+
+            fixture.OfType<SomeSagaData>().First().JustSomeText.ShouldBe(someSagaData.JustSomeText);
+        }
+
         public class CounterpartUpdater : Saga<CounterpartData>,
             IAmInitiatedBy<CounterpartCreated>,
             IAmInitiatedBy<CounterpartUpdated>

--- a/src/Rebus/Testing/SagaFixture.cs
+++ b/src/Rebus/Testing/SagaFixture.cs
@@ -12,7 +12,7 @@ namespace Rebus.Testing
     /// <summary>
     /// Saga fixture that can help unit testing sagas.
     /// </summary>
-    public class SagaFixture<TSagaData> where TSagaData : class, ISagaData, new()
+    public class SagaFixture<TSagaData> : IEnumerable<TSagaData> where TSagaData : class, ISagaData, new()
     {
         readonly List<TSagaData> deletedSagaData = new List<TSagaData>();
         readonly Dispatcher dispatcher;
@@ -334,6 +334,26 @@ namespace Rebus.Testing
             public event Action<ISagaData> Deleted;
 
             public event Action CouldNotCorrelate;
+        }
+
+        /// <summary>
+        /// Adds the given saga data to the underlying persister. Please note that the usual uniqueness constraint cannot be enforced
+        /// when adding saga data this way, simply because it is impossible to know at this point which properties are correlation
+        /// properties.
+        /// </summary>
+        public void Add(TSagaData someSagaData)
+        {
+            AddSagaData(someSagaData);
+        }
+
+        IEnumerator<TSagaData> IEnumerable<TSagaData>.GetEnumerator()
+        {
+            return AvailableSagaData.GetEnumerator();
+        }
+
+        public IEnumerator GetEnumerator()
+        {
+            return AvailableSagaData.GetEnumerator();
         }
     }
 }


### PR DESCRIPTION
var sf = new SagaFixture(...)
sf.AddSagaData(new SagaData());
becomes:
new SagaFixture(){ new SagaData()}
Also expose AvailableSagaData as IEnumerable on the class (partly to support the collection initializer pattern, and maybe avoid some demeter)

Dunno if AddSagaData should be made obsolete and the rest of the overloads supported aswell?
