### PR TITLE
Fix sql server timeout storage primary key

### DIFF
--- a/src/Rebus/Persistence/SqlServer/SqlServerTimeoutStorage.cs
+++ b/src/Rebus/Persistence/SqlServer/SqlServerTimeoutStorage.cs
@@ -99,7 +99,7 @@ namespace Rebus.Persistence.SqlServer
                 {
                     command.CommandText =
                         string.Format(
-                            @"select id, time_to_return, correlation_id, saga_id, reply_to, custom_data from [{0}] where time_to_return <= @current_time",
+                            @"select id, time_to_return, correlation_id, saga_id, reply_to, custom_data from [{0}] where time_to_return <= @current_time order by time_to_return asc",
                             timeoutsTableName);
 
                     command.Parameters.AddWithValue("current_time", RebusTimeMachine.Now());


### PR DESCRIPTION
Hi,

I've made the change we discussed last week to SqlServerStorage: Rather than considering time_to_return the primary key, introduce a bigint id and use that. This is a breaking change for existing timeout tables. The effect of treating time_to_return as the primary key was that messages deferred to the same time (within 3ms) as a previously deferred message were silently lost, since primary key violation exceptions were specifically swallowed.

I also increased the precision of time_to_return from 3ms to 100ns. The effect of this is perhaps limited, since the precision of DateTime.UtcNow is between 1ms and 15ms. Still, it’s recommended practice.

Did I mention how cool I think it is that you use DateTime.UtcNow rather than DateTime.Now? We still see that way too seldom.

/krivin
