### PR TITLE
Allow number of workers to be specified in Configuration, per bus.

### DIFF
--- a/src/Rebus/Bus/RebusBus.cs
+++ b/src/Rebus/Bus/RebusBus.cs
@@ -116,22 +116,29 @@ namespace Rebus.Bus
                 .Where(r => !ReferenceEquals(null, r));
         }
 
-        /// <summary>
-        /// Starts the bus
-        /// </summary>
-        public IBus Start()
+        private static int GetConfiguredNumberOfWorkers()
         {
             const int defaultNumberOfWorkers = 1;
 
-            var numberOfWorkers = RebusConfigurationSection
+            return RebusConfigurationSection
                 .GetConfigurationValueOrDefault(s => s.Workers, defaultNumberOfWorkers)
                 .GetValueOrDefault(defaultNumberOfWorkers);
-
-            InternalStart(numberOfWorkers);
-
-            return this;
         }
 
+        /// <summary>
+        /// Starts the bus
+        /// </summary>
+        public RebusBus Start()
+        {
+            InternalStart(GetConfiguredNumberOfWorkers());
+            return this;
+        }
+        IBus IStartableBus.Start()
+        {
+            InternalStart(GetConfiguredNumberOfWorkers());
+            return this;
+        }
+ 
         /// <summary>
         /// Starts the <see cref="RebusBus"/> with the specified number of worker threads.
         /// </summary>
@@ -144,6 +151,14 @@ namespace Rebus.Bus
             return this;
         }
 
+        IBus IStartableBus.Start(int numberOfWorkers)
+        {
+            Guard.GreaterThanOrEqual(numberOfWorkers, 0, "numberOfWorkers");
+
+            InternalStart(numberOfWorkers);
+
+            return this;
+        }
 
         /// <summary>
         /// Sends the specified message to the destination as specified by the currently
@@ -847,5 +862,5 @@ element and use e.g. .Transport(t => t.UseMsmqInOneWayClientMode())"));
                 cleanupTimer.Dispose();
             }
         }
-    }
+   }
 }

--- a/src/Rebus/IStartableBus.cs
+++ b/src/Rebus/IStartableBus.cs
@@ -9,5 +9,10 @@ namespace Rebus
         /// Starts the bus.
         /// </summary>
         IBus Start();
+
+        /// <summary>
+        /// Starts the <see cref="RebusBus"/> with the specified number of worker threads.
+        /// </summary>
+        IBus Start(int numberOfWorkers);
     }
 }


### PR DESCRIPTION
On one hand, the ability to easily assign multiple workers to a single bus is powerful and useful. On the other, the semantics of messages in a bus may not allow multiple workers (the order they are processed may be important). This commit allows different busses in the same process to be configured differently with respect to the number of workers to suit their needs.
