### PR TITLE
Update XmlSubscriptionStorage.cs

### DIFF
--- a/src/Rebus/Persistence/Xml/XmlSubscriptionStorage.cs
+++ b/src/Rebus/Persistence/Xml/XmlSubscriptionStorage.cs
@@ -25,7 +25,7 @@ namespace Rebus.Persistence.Xml
 
             var dir = Path.GetDirectoryName(xmlFilePath);
             
-            if (!Directory.Exists(dir))
+            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
                 Directory.CreateDirectory(dir);
 
             this.xmlFilePath = xmlFilePath;


### PR DESCRIPTION
The old code assumes there's a directory in the path, which might not be true. Fixed so it works even without a directory in the path.

Ex: "subscriptions.xml" doesn't work, but ".\subscriptions.xml" works.

Another method could be to throw a meaningful exception if dir is null/empty.
