### PR TITLE
Update LoadBalancer.cs

### DIFF
--- a/src/Rebus.MsmqLoadBalancer/LoadBalancer.cs
+++ b/src/Rebus.MsmqLoadBalancer/LoadBalancer.cs
@@ -71,6 +71,9 @@ namespace Rebus.MsmqLoadBalancer
 
         string GetNextDestination()
         {
+            // Guard against int.MaxValue - reset to 0
+            Interlocked.CompareExchange(ref roundRobinCounter, 0, int.MaxValue);
+            
             var indexOfThisDestination = Interlocked.Increment(ref roundRobinCounter)
                                          %destinationQueueNames.Count;
 


### PR DESCRIPTION
Possible bug if the LoadBalancer lives to process more than `int.MaxValue` messages.
`Interlocked.Increment(ref roundRobinCounter)` would 'overflow' to `int.MinValue` (a negative number) and would cause the `indexOfThisDestination` be negative too, causing an `IndexOutOfRangeException`

> Looked at adding a unit test for it, but would probably run too slow.
