### PR TITLE
Fixing bug-fix 'MSMQ transaction leak'. 

### DIFF
--- a/src/Rebus.Tests/Bugs/AmbientTransactionContextNeverCleansUp.cs
+++ b/src/Rebus.Tests/Bugs/AmbientTransactionContextNeverCleansUp.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Transactions;
+﻿using System.Transactions;
 using NUnit.Framework;
 using Rebus.Bus;
 using Shouldly;
@@ -37,8 +33,18 @@ namespace Rebus.Tests.Bugs
             cleanupCalled.ShouldBe(0);
             tx.Dispose();
             cleanupCalled.ShouldBe(1);
+        }
 
+        [Test]
+        public void CleanupIsPerformedEvenIfTransactionIsNotCommitted()
+        {
+            int cleanupCalled = 0;
+            var tx = new TransactionScope();
+            var ctx = new AmbientTransactionContext();
+            ctx.Cleanup += () => { cleanupCalled++; };
             
+            tx.Dispose();
+            cleanupCalled.ShouldBe(1);
         }
     }
 }

--- a/src/Rebus/Bus/AmbientTransactionContext.cs
+++ b/src/Rebus/Bus/AmbientTransactionContext.cs
@@ -23,7 +23,6 @@ namespace Rebus.Bus
             }
 
             Transaction.Current.EnlistVolatile(this, EnlistmentOptions.None);
-            Transaction.Current.TransactionCompleted += OnTransactionCompleted;
 
             TransactionContext.Set(this);
         }
@@ -90,7 +89,7 @@ namespace Rebus.Bus
             }
             finally
             {
-                TransactionContext.Clear();
+                RunCleanup();
             }
         }
 
@@ -107,7 +106,7 @@ namespace Rebus.Bus
             }
             finally
             {
-                TransactionContext.Clear();
+                RunCleanup();
             }
         }
 
@@ -122,21 +121,16 @@ namespace Rebus.Bus
             }
             finally
             {
-                TransactionContext.Clear();
+                RunCleanup();
             }
         }
 
-
-        /// <summary>
-        /// Performs necessary cleanup actions, clearing the current <see cref="TransactionContext"/>
-        /// </summary>
-        void OnTransactionCompleted(object sender, TransactionEventArgs transactionEventArgs)
+        public void RunCleanup()
         {
             try
             {
                 Cleanup();
             }
-
             finally
             {
                 TransactionContext.Clear();


### PR DESCRIPTION
It is problematic to use both EnlistVolatile and the TransactionCompleted event when hooking into TransactionScope. We have experienced TransactionCompleted (where cleanup takes place) being called before Commit.
