### PR TITLE
Added the posibility to configure the JsonSerializer to serialize enums as strings

### DIFF
--- a/src/Rebus.Tests/Serialization/Json/TestJsonMessageSerializer.cs
+++ b/src/Rebus.Tests/Serialization/Json/TestJsonMessageSerializer.cs
@@ -183,5 +183,34 @@ namespace Rebus.Tests.Serialization.Json
         {
             public string AnotherField { get; set; }            
         }
+
+        enum SomeEnumValue
+        {
+            IAmTheValueOne,
+            IAmTheValueTwo
+        }
+
+        class SomeMessageWithEnums
+        {
+            public SomeEnumValue SomeEnum { get; set; }
+        }
+
+        [TestCase("utf-7")]
+        [TestCase("utf-8")]
+        [TestCase("utf-16")]
+        [TestCase("utf-32")]
+        public void EnumValueIsSerializedAsString(string encodingWebName)
+        {
+            var encoding = Encoding.GetEncoding(encodingWebName);
+            // arrange
+            serializer.SpecifyEncoding(encoding);
+            serializer.SerializeEnumAsStrings(true);
+
+            // act
+            var message = serializer.Serialize(new Message {Messages = new[] {new SomeMessageWithEnums { SomeEnum = SomeEnumValue.IAmTheValueTwo }}});
+
+            // assert
+            encoding.GetString(message.Body).ShouldContain(SomeEnumValue.IAmTheValueTwo.ToString());
+        }
     }
 }

--- a/src/Rebus/Configuration/JsonSerializationOptions.cs
+++ b/src/Rebus/Configuration/JsonSerializationOptions.cs
@@ -49,5 +49,14 @@ namespace Rebus.Configuration
             jsonMessageSerializer.SpecifyEncoding(encoding);
             return this;
         }
+
+        /// <summary>
+        /// Configure the serializer to serialize the enums as string.
+        /// </summary>
+        public JsonSerializationOptions SerializeEnumAsStrings(bool camelCaseText)
+        {
+            jsonMessageSerializer.SerializeEnumAsStrings(camelCaseText);
+            return this;
+        }
     }
 }

--- a/src/Rebus/Serialization/Json/JsonMessageSerializer.cs
+++ b/src/Rebus/Serialization/Json/JsonMessageSerializer.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Text;
 using System.Threading;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
 using Rebus.Messages;
 using Rebus.Extensions;
@@ -257,6 +258,14 @@ namespace Rebus.Serialization.Json
         public void SpecifyEncoding(Encoding encoding)
         {
             customEncoding = encoding;
+        }
+
+        /// <summary>
+        /// Configure the serializer to serialize the enums as string.
+        /// </summary>
+        public void SerializeEnumAsStrings(bool camelCaseText)
+        {
+            settings.Converters.Add(new StringEnumConverter { CamelCaseText = camelCaseText });
         }
     }
 }


### PR DESCRIPTION
Now you can configure the JsonSerializer to serialize enums as its string representation.

```
var bus = Configure.With(adapter)
...
.Serialization(s => s.UseJsonSerializer().SerializeEnumAsStrings(false))
...
.CreateBus();
```

I think that is usefull when troubleshooting, as you don´t have to make the "mental translation" between the enum representation and its value.
