### PR TITLE
Fix for #261

### DIFF
--- a/src/Rebus/Persistence/SqlServer/SqlServerMagic.cs
+++ b/src/Rebus/Persistence/SqlServer/SqlServerMagic.cs
@@ -17,7 +17,7 @@ namespace Rebus.Persistence.SqlServer
                 {
                     command.Transaction = transaction;
                 }
-                command.CommandText = "select * from sys.Tables";
+                command.CommandText = "select * from sys.tables";
 
                 using (var reader = command.ExecuteReader())
                 {


### PR DESCRIPTION
A fix for bug when ensuring tables are created in Sql Server. All
documentation I found online points to lowercase being the correct
spelling in Sql Server.
