### PR TITLE
sagaContext can be null, if event is used in saga and elsewhere

### DIFF
--- a/src/Rebus/SagaContext.cs
+++ b/src/Rebus/SagaContext.cs
@@ -44,7 +44,7 @@ namespace Rebus
         {
             if (messageContext != null)
             {
-                messageContext.Items[SagaContextItemKey] = null;
+                messageContext.Items.Remove(SagaContextItemKey);
             }
         }
     }


### PR DESCRIPTION
![ajabaiy 1](https://cloud.githubusercontent.com/assets/156927/4627853/b777346a-538f-11e4-9712-c8324e313f97.png)
