### PR TITLE
Modified SqlServerStorage to accept name of a connectionstring

### DIFF
--- a/src/Rebus/Persistence/SqlServer/SqlServerSagaPersister.cs
+++ b/src/Rebus/Persistence/SqlServer/SqlServerSagaPersister.cs
@@ -38,8 +38,8 @@ namespace Rebus.Persistence.SqlServer
         /// Constructs the persister with the ability to create connections to SQL Server using the specified connection string.
         /// This also means that the persister will manage the connection by itself, closing it when it has stopped using it.
         /// </summary>
-        public SqlServerSagaPersister(string connectionString, string sagaIndexTableName, string sagaTableName)
-            : base(connectionString)
+        public SqlServerSagaPersister(string connectionStringOrConnectionStringName, string sagaIndexTableName, string sagaTableName)
+            : base(connectionStringOrConnectionStringName)
         {
             Initialize(sagaIndexTableName, sagaTableName);
         }

--- a/src/Rebus/Persistence/SqlServer/SqlServerStorage.cs
+++ b/src/Rebus/Persistence/SqlServer/SqlServerStorage.cs
@@ -24,9 +24,9 @@ namespace Rebus.Persistence.SqlServer
             releaseConnection = c => { };
         }
 
-        protected SqlServerStorage(string connectionString)
+        protected SqlServerStorage(string connectionStringOrConnectionStringName)
         {
-            getConnection = () => CreateConnection(connectionString);
+            getConnection = () => CreateConnection(connectionStringOrConnectionStringName);
             commitAction = h => h.Commit();
             rollbackAction = h => h.RollBack();
             releaseConnection = c => c.Dispose();
@@ -37,9 +37,10 @@ namespace Rebus.Persistence.SqlServer
         /// </summary>
         /// <param name="connectionString"></param>
         /// <returns></returns>
-        protected static ConnectionHolder CreateConnection(string connectionString)
+        protected static ConnectionHolder CreateConnection(string connectionStringOrConnectionStringName)
         {
-            var connection = new SqlConnection(connectionString);
+            var connectionStringToUse = Rebus.Shared.ConnectionStringUtil.GetConnectionStringToUse(connectionStringOrConnectionStringName);
+            var connection = new SqlConnection(connectionStringToUse);
             connection.Open();
 
             if (Transaction.Current == null)

--- a/src/Rebus/Persistence/SqlServer/SqlServerSubscriptionStorage.cs
+++ b/src/Rebus/Persistence/SqlServer/SqlServerSubscriptionStorage.cs
@@ -25,7 +25,8 @@ namespace Rebus.Persistence.SqlServer
         /// Constructs the storage with the ability to create connections to SQL Server using the specified connection string.
         /// This also means that the storage will manage the connection by itself, closing it when it has stopped using it.
         /// </summary>
-        public SqlServerSubscriptionStorage(string connectionString, string subscriptionsTableName):base(connectionString)
+        public SqlServerSubscriptionStorage(string connectionStringOrConnectionStringName, string subscriptionsTableName)
+            : base(connectionStringOrConnectionStringName)
         {
             this.subscriptionsTableName = subscriptionsTableName;
         }
@@ -35,7 +36,8 @@ namespace Rebus.Persistence.SqlServer
         /// to easily enlist in any ongoing SQL transaction magic that might be going on. This means that the storage will assume
         /// that someone else manages the connection's lifetime.
         /// </summary>
-        public SqlServerSubscriptionStorage(Func<ConnectionHolder> connectionFactoryMethod, string subscriptionsTableName):base(connectionFactoryMethod)
+        public SqlServerSubscriptionStorage(Func<ConnectionHolder> connectionFactoryMethod, string subscriptionsTableName)
+            : base(connectionFactoryMethod)
         {
             this.subscriptionsTableName = subscriptionsTableName;
         }

--- a/src/Rebus/Rebus.csproj
+++ b/src/Rebus/Rebus.csproj
@@ -106,6 +106,7 @@
     <Compile Include="Persistence\SqlServer\SqlServerStorage.cs" />
     <Compile Include="SagaContext.cs" />
     <Compile Include="Serialization\Json\TypeDescriptor.cs" />
+    <Compile Include="Shared\ConnectionStringUtil.cs" />
     <Compile Include="Testing\FakeBus.cs" />
     <Compile Include="Testing\SagaFixture.cs" />
     <Compile Include="TimedExtensions.cs" />

--- a/src/Rebus/Shared/ConnectionstringUtil.cs
+++ b/src/Rebus/Shared/ConnectionstringUtil.cs
@@ -1,0 +1,16 @@
+﻿using System.Configuration;
+
+namespace Rebus.Shared
+{
+    internal static class ConnectionStringUtil
+    {
+        internal static string GetConnectionStringToUse(string connectionStringOrConnectionStringName)
+        {
+            var connectionStringSettings = ConfigurationManager.ConnectionStrings[connectionStringOrConnectionStringName];
+            var connectionStringToUse = connectionStringSettings != null
+                                            ? connectionStringSettings.ConnectionString
+                                            : connectionStringOrConnectionStringName;
+            return connectionStringToUse;
+        }
+    }
+}

--- a/src/Rebus/Transports/Sql/SqlServerMessageQueueConfigurationExtension.cs
+++ b/src/Rebus/Transports/Sql/SqlServerMessageQueueConfigurationExtension.cs
@@ -29,7 +29,7 @@ namespace Rebus.Transports.Sql
         /// </summary>
         public static SqlServerMessageQueueOptions UseSqlServerInOneWayClientMode(this RebusTransportConfigurer configurer, string connectionStringOrConnectionStringName)
         {
-            var connectionStringToUse = GetConnectionStringToUse(connectionStringOrConnectionStringName);
+            var connectionStringToUse = Rebus.Shared.ConnectionStringUtil.GetConnectionStringToUse(connectionStringOrConnectionStringName);
             var sqlServerMessageQueue = SqlServerMessageQueue.Sender(connectionStringToUse, DefaultMessagesTableName);
 
             configurer.UseSender(sqlServerMessageQueue);
@@ -94,7 +94,7 @@ A more full example configuration snippet can be seen here:
 
         static SqlServerMessageQueueOptions DoIt(string connectionStringOrConnectionStringName, RebusTransportConfigurer configurer, string messageTableName, string inputQueueName, string errorQueueName)
         {
-            var connectionStringToUse = GetConnectionStringToUse(connectionStringOrConnectionStringName);
+            var connectionStringToUse = Rebus.Shared.ConnectionStringUtil.GetConnectionStringToUse(connectionStringOrConnectionStringName);
 
             if (string.IsNullOrEmpty(inputQueueName))
             {
@@ -108,15 +108,6 @@ A more full example configuration snippet can be seen here:
             configurer.UseErrorTracker(new ErrorTracker(errorQueueName));
 
             return new SqlServerMessageQueueOptions(sqlServerMessageQueue);
-        }
-
-        static string GetConnectionStringToUse(string connectionStringOrConnectionStringName)
-        {
-            var connectionStringSettings = ConfigurationManager.ConnectionStrings[connectionStringOrConnectionStringName];
-            var connectionStringToUse = connectionStringSettings != null
-                                            ? connectionStringSettings.ConnectionString
-                                            : connectionStringOrConnectionStringName;
-            return connectionStringToUse;
         }
     }
 }


### PR DESCRIPTION
Moved GetConnectionStringToUse -method from
SqlServerMessageQueueConfigurationExtension to a new
ConnectionStringUtil-class in Shared -namespace so it also usable from
SqlServerStorage -class.

Modified SqlServerStorage to accept name of a connectionstring in
addition to an actual connectionstring.

Modified the name of the parameter in the constructor of
SqlServerStorage to reflect new behaviour. Also modified the parameter
names in class inheriting from SqlServerStorage.
