### PR TITLE
Feature sqlservermessagequeuetablename

### DIFF
--- a/src/Rebus/Configuration/RebusConfigurationSection.cs
+++ b/src/Rebus/Configuration/RebusConfigurationSection.cs
@@ -33,7 +33,6 @@ namespace Rebus.Configuration
         const string MappingsCollectionPropertyName = "endpoints";
         const string RijndaelCollectionPropertyName = "rijndael";
         const string InputQueueAttributeName = "inputQueue";
-        const string MessageTableNameAttributeName = "messageTableName";
         const string TimeoutManagerAttributeName = "timeoutManager";
         const string AddressAttributeName = "address";
         const string ErrorQueueAttributeName = "errorQueue";
@@ -69,16 +68,6 @@ namespace Rebus.Configuration
         {
             get { return (string)this[InputQueueAttributeName]; }
             set { this[InputQueueAttributeName] = value; }
-        }
-
-        /// <summary>
-        /// Gets the message table name
-        /// </summary>
-        [ConfigurationProperty(MessageTableNameAttributeName)]
-        public string MessageTableName
-        {
-            get { return (string)this[MessageTableNameAttributeName]; }
-            set { this[MessageTableNameAttributeName] = value; }
         }
 
         /// <summary>

--- a/src/Rebus/Transports/Sql/SqlServerMessageQueueConfigurationExtension.cs
+++ b/src/Rebus/Transports/Sql/SqlServerMessageQueueConfigurationExtension.cs
@@ -70,18 +70,6 @@ namespace Rebus.Transports.Sql
         /// queue name will be deduced from the Rebus configuration section in the application
         /// configuration file. The input queue will be automatically created if it doesn't exist.
         /// </summary>
-        public static SqlServerMessageQueueOptions UseSqlServerAndGetInputQueueNameAndMessageTableNameFromAppConfig(this RebusTransportConfigurer configurer, string connectionStringOrConnectionStringName)
-        {            
-            string messageTableNameToUse = RebusConfigurationSection.GetConfigurationValueOrDefault(m => m.MessageTableName, DefaultMessagesTableName);
-            
-            return configurer.UseSqlServerAndGetInputQueueNameFromAppConfig(connectionStringOrConnectionStringName, messageTableNameToUse);
-        }
-
-        /// <summary>
-        /// Specifies that you want to use Sql Server to both send and receive messages. The input
-        /// queue name will be deduced from the Rebus configuration section in the application
-        /// configuration file. The input queue will be automatically created if it doesn't exist.
-        /// </summary>
         public static SqlServerMessageQueueOptions UseSqlServerAndGetInputQueueNameFromAppConfig(this RebusTransportConfigurer configurer, string connectionStringOrConnectionStringName, string MessageTableName = null)
         {
             try


### PR DESCRIPTION
Added overloads that enable defining message table name in Sql Server transport.
