### PR TITLE
correct spelling error in ReturnToSourceQueue tools

### DIFF
--- a/src/Rebus.ReturnToSourceQueue.Msmq/Program.cs
+++ b/src/Rebus.ReturnToSourceQueue.Msmq/Program.cs
@@ -42,7 +42,7 @@ namespace Rebus.ReturnToSourceQueue.Msmq
         {
             if (!parameters.DryRun.HasValue && parameters.Interactive)
             {
-                var dryrun = PromptChar(new[] {'d', 'm'}, "Perform a (d)ry dun or actually (m) move messages?");
+                var dryrun = PromptChar(new[] {'d', 'm'}, "Perform a (d)ry run or actually (m) move messages?");
 
                 switch (dryrun)
                 {

--- a/src/Rebus.ReturnToSourceQueue.RabbitMQ/Program.cs
+++ b/src/Rebus.ReturnToSourceQueue.RabbitMQ/Program.cs
@@ -41,7 +41,7 @@ namespace Rebus.ReturnToSourceQueue.RabbitMQ
         {
             if (!parameters.DryRun.HasValue && parameters.Interactive)
             {
-                var dryrun = PromptChar(new[] { 'd', 'm' }, "Perform a (d)ry dun or actually (m) move messages?");
+                var dryrun = PromptChar(new[] { 'd', 'm' }, "Perform a (d)ry run or actually (m) move messages?");
 
                 switch (dryrun)
                 {


### PR DESCRIPTION
Minimal change in both ReturnToSourceQueue tools. "Dry run" instead of "Dry dun".
