### PR TITLE
Support for IHandleMessagesAsync<T> in containers

### DIFF
--- a/src/Rebus.Autofac/AutofacContainerAdapter.cs
+++ b/src/Rebus.Autofac/AutofacContainerAdapter.cs
@@ -46,7 +46,9 @@ namespace Rebus.Autofac
             var context = MessageContext.GetCurrent();
             var lifetimeScope = (ILifetimeScope)context.Items[ContextKey];
 
-            return lifetimeScope.Resolve<IEnumerable<IHandleMessages<T>>>().ToArray();
+            IEnumerable<IHandleMessages> handlers = lifetimeScope.Resolve<IEnumerable<IHandleMessages<T>>>();
+            IEnumerable<IHandleMessages> asyncHandlers = lifetimeScope.Resolve<IEnumerable<IHandleMessagesAsync<T>>>();
+            return handlers.Union(asyncHandlers).ToArray();
         }
 
         /// <summary>

--- a/src/Rebus.Castle.Windsor/WindsorContainerAdapter.cs
+++ b/src/Rebus.Castle.Windsor/WindsorContainerAdapter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using Castle.MicroKernel.Registration;
 using Castle.Windsor;
 using Rebus.Configuration;
@@ -25,7 +26,10 @@ namespace Rebus.Castle.Windsor
 
         public IEnumerable<IHandleMessages> GetHandlerInstancesFor<T>()
         {
-            return container.ResolveAll<IHandleMessages<T>>();
+            IEnumerable<IHandleMessages> handlers = container.ResolveAll<IHandleMessages<T>>();
+            IEnumerable<IHandleMessages> asyncHandlers = container.ResolveAll<IHandleMessagesAsync<T>>();
+
+            return handlers.Union(asyncHandlers);
         }
 
         public void Release(IEnumerable handlerInstances)

--- a/src/Rebus.Ninject/NinjectContainerAdapter.cs
+++ b/src/Rebus.Ninject/NinjectContainerAdapter.cs
@@ -15,10 +15,12 @@ namespace Rebus.Ninject
         {
             this.kernel = kernel;
         }
-
+        
         public IEnumerable<IHandleMessages> GetHandlerInstancesFor<T>()
         {
-            return kernel.GetAll<IHandleMessages<T>>().ToArray();
+            IEnumerable<IHandleMessages> handlers = kernel.GetAll<IHandleMessages<T>>();
+            IEnumerable<IHandleMessages> asynchandlers = kernel.GetAll<IHandleMessagesAsync<T>>();
+            return handlers.Union(asynchandlers).ToArray();
         }
 
         public void Release(IEnumerable handlerInstances)

--- a/src/Rebus.SimpleInjector/SimpleInjectorAdapter.cs
+++ b/src/Rebus.SimpleInjector/SimpleInjectorAdapter.cs
@@ -26,9 +26,10 @@ namespace Rebus.SimpleInjector
 
         public IEnumerable<IHandleMessages> GetHandlerInstancesFor<T>()
         {
-            var handlers =  container.GetAllInstances(typeof (IHandleMessages<T>)).Cast<IHandleMessages<T>>().ToArray();
+            IEnumerable<IHandleMessages> handlers = container.GetAllInstances(typeof(IHandleMessages<T>)).Cast<IHandleMessages<T>>();
+            IEnumerable<IHandleMessages> asyncHandlers =  container.GetAllInstances(typeof (IHandleMessagesAsync<T>)).Cast<IHandleMessagesAsync<T>>();
 
-            return handlers;
+            return handlers.Union(asyncHandlers).ToArray();
         }
 
         public void Release(IEnumerable handlerInstances)

--- a/src/Rebus.StructureMap/StructureMapContainerAdapter.cs
+++ b/src/Rebus.StructureMap/StructureMapContainerAdapter.cs
@@ -23,7 +23,9 @@ namespace Rebus.StructureMap
 
         public IEnumerable<IHandleMessages> GetHandlerInstancesFor<T>()
         {
-            return container.GetAllInstances<IHandleMessages<T>>();
+            IEnumerable<IHandleMessages> handlers = container.GetAllInstances<IHandleMessages<T>>();
+            IEnumerable<IHandleMessages> asyncHandlers = container.GetAllInstances<IHandleMessagesAsync<T>>();
+            return handlers.Union(asyncHandlers);
         }
 
         public void Release(IEnumerable handlerInstances)

--- a/src/Rebus.Unity/UnityContainerAdapter.cs
+++ b/src/Rebus.Unity/UnityContainerAdapter.cs
@@ -18,7 +18,9 @@ namespace Rebus.Unity
 
         public IEnumerable<IHandleMessages> GetHandlerInstancesFor<T>()
         {
-            return unityContainer.ResolveAll<IHandleMessages<T>>().ToArray();
+            IEnumerable<IHandleMessages> handlers = unityContainer.ResolveAll<IHandleMessages<T>>();
+            IEnumerable<IHandleMessages> asyncHandlers = unityContainer.ResolveAll<IHandleMessagesAsync<T>>();
+            return handlers.Union(asyncHandlers).ToArray();
         }
 
         public void Release(IEnumerable handlerInstances)


### PR DESCRIPTION
Added unit tests for this: MultipleCallsToGetYieldsNewAsyncHandlerInstances and CanGetAsyncHandlerInstancesAndReleaseThemAfterwardsAsExpected in TestContainerAdapters.
