### PR TITLE
Assembly auto subscribe

### DIFF
--- a/src/Rebus.Extensions/Properties/AssemblyInfo.cs
+++ b/src/Rebus.Extensions/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Rebus.Extensions")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Rebus.Extensions")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("01006638-c17a-4a14-915f-b288b94d5e1d")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Rebus.Extensions/Rebus.Extensions.csproj
+++ b/src/Rebus.Extensions/Rebus.Extensions.csproj
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{7551FD46-EAE0-4041-B747-80102FF625F8}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Rebus.Extensions</RootNamespace>
+    <AssemblyName>Rebus.Extensions</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="RebusBusExtensions.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Rebus\Rebus.csproj">
+      <Project>{F57A06FA-F471-49C8-A92D-85D5A27055C4}</Project>
+      <Name>Rebus</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Rebus.Extensions/RebusBusExtensions.cs
+++ b/src/Rebus.Extensions/RebusBusExtensions.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Rebus.Bus;
+
+namespace Rebus.Extensions
+{
+    public static class RebusBusExtensions
+    {
+        /// <summary>
+        ///     Scans the assemblies supplied in <paramref name="assemblies" /> for handlers that implement
+        ///     <see cref="IHandleMessages{TMessage}" /> and adds a subscription for the handled message types.
+        /// </summary>
+        public static void SubscribeByScanningForHandlers(this RebusBus bus, params Assembly[] assemblies)
+        {
+            foreach (var messageType in GetTypesOfMessagesHandledByRebus(assemblies))
+            {
+                bus.Subscribe(messageType);
+            }
+        }
+
+        static IEnumerable<Type> GetTypesOfMessagesHandledByRebus(Assembly[] assemblies)
+        {
+            return assemblies.SelectMany(x => x.GetTypes())
+                .SelectMany(x => x.GetInterfaces())
+                .Where(IsGenericRebusHandler)
+                .SelectMany(x => x.GenericTypeArguments)
+                .Distinct();
+        }
+
+        static bool IsGenericRebusHandler(Type t)
+        {
+            return t.IsGenericType && t.GetGenericTypeDefinition() == typeof (IHandleMessages<>);
+        }
+    }
+}

--- a/src/Rebus.Tests/Rebus.Tests.csproj
+++ b/src/Rebus.Tests/Rebus.Tests.csproj
@@ -457,6 +457,10 @@
       <Project>{2178D256-94D6-4443-B23B-53F723184441}</Project>
       <Name>Rebus.Castle.Windsor</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Rebus.Extensions\Rebus.Extensions.csproj">
+      <Project>{7551FD46-EAE0-4041-B747-80102FF625F8}</Project>
+      <Name>Rebus.Extensions</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Rebus.HttpGateway\Rebus.HttpGateway.csproj">
       <Project>{3E817332-6161-46A1-8597-0E54BAD23DE0}</Project>
       <Name>Rebus.HttpGateway</Name>

--- a/src/Rebus.Tests/Unit/TestRebusBus.cs
+++ b/src/Rebus.Tests/Unit/TestRebusBus.cs
@@ -361,7 +361,7 @@ Or should it?")]
             receiveMessages.SetInputQueue("my input queue");
 
             // act
-            bus.SubscribeForAssemblyHandlers(assembly1, assembly2);
+            bus.SubscribeByScanningForHandlers(assembly1, assembly2);
 
             // assert
             Action<Type, string> assertSubscriptionMessageCalledForType = (t, endPointName) =>

--- a/src/Rebus.Tests/Unit/TestRebusBus.cs
+++ b/src/Rebus.Tests/Unit/TestRebusBus.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 using Raven.Imports.Newtonsoft.Json;
 using Rebus.Bus;
 using Rebus.Configuration;
+using Rebus.Extensions;
 using Rebus.Messages;
 using Rebus.Shared;
 using Rebus.Testing;

--- a/src/Rebus.sln
+++ b/src/Rebus.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30324.0
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{37452F2B-E43B-4A39-9956-E3FB17DA2042}"
 	ProjectSection(SolutionItems) = preProject
@@ -107,6 +107,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rebus.PostgreSql", "Rebus.PostgreSql\Rebus.PostgreSql.csproj", "{BA89E035-AD58-42A9-AC55-443EAD2527CE}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rebus.SimpleInjector", "Rebus.SimpleInjector\Rebus.SimpleInjector.csproj", "{44A9CDF9-3A76-4B4C-AA1D-A34AD7FC2BD5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rebus.Extensions", "Rebus.Extensions\Rebus.Extensions.csproj", "{7551FD46-EAE0-4041-B747-80102FF625F8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -364,6 +366,16 @@ Global
 		{44A9CDF9-3A76-4B4C-AA1D-A34AD7FC2BD5}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{44A9CDF9-3A76-4B4C-AA1D-A34AD7FC2BD5}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{44A9CDF9-3A76-4B4C-AA1D-A34AD7FC2BD5}.Release|x86.ActiveCfg = Release|Any CPU
+		{7551FD46-EAE0-4041-B747-80102FF625F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7551FD46-EAE0-4041-B747-80102FF625F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7551FD46-EAE0-4041-B747-80102FF625F8}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{7551FD46-EAE0-4041-B747-80102FF625F8}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{7551FD46-EAE0-4041-B747-80102FF625F8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7551FD46-EAE0-4041-B747-80102FF625F8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7551FD46-EAE0-4041-B747-80102FF625F8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7551FD46-EAE0-4041-B747-80102FF625F8}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{7551FD46-EAE0-4041-B747-80102FF625F8}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{7551FD46-EAE0-4041-B747-80102FF625F8}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -398,6 +410,7 @@ Global
 		{994133F4-799B-4878-8AE8-29F5D7E00B8D} = {48006958-82E0-46B0-81CB-0A6FC7BA1A75}
 		{BA89E035-AD58-42A9-AC55-443EAD2527CE} = {9FAD5BC1-8B70-4E51-816C-CEE718EB5E5C}
 		{44A9CDF9-3A76-4B4C-AA1D-A34AD7FC2BD5} = {68CCD78A-BFCE-4071-BE9B-C375180375BA}
+		{7551FD46-EAE0-4041-B747-80102FF625F8} = {35C585ED-8CB0-48D1-83FC-375548298233}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		EnterpriseLibraryConfigurationToolBinariesPath = packages\Unity.2.1.505.0\lib\NET35;packages\Unity.2.1.505.2\lib\NET35

--- a/src/Rebus.sln.DotSettings
+++ b/src/Rebus.sln.DotSettings
@@ -7,5 +7,6 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PublicFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:String x:Key="/Default/FilterSettingsManager/AttributeFilterXml/@EntryValue">&lt;data /&gt;</s:String>
 	<s:String x:Key="/Default/FilterSettingsManager/CoverageFilterXml/@EntryValue">&lt;data&gt;&lt;IncludeFilters /&gt;&lt;ExcludeFilters /&gt;&lt;/data&gt;</s:String></wpf:ResourceDictionary>

--- a/src/Rebus/Bus/RebusBus.cs
+++ b/src/Rebus/Bus/RebusBus.cs
@@ -309,31 +309,6 @@ namespace Rebus.Bus
         }
 
         /// <summary>
-        /// Scans the assemblies supplied in <paramref name="assemblies"/> for handlers that implement 
-        /// <see cref="IHandleMessages{TMessage}"/> and adds a subscription for the handled message types.
-        /// </summary>
-        public void SubscribeByScanningForHandlers(params Assembly[] assemblies)
-        {
-            foreach (var messageType in GetTypesOfMessagesHandledByRebus(assemblies))
-            {
-                Subscribe(messageType);
-            }
-        }
-
-        private IEnumerable<Type> GetTypesOfMessagesHandledByRebus(Assembly[] assemblies)
-        {
-            return assemblies.SelectMany(x => x.GetTypes())
-                .SelectMany(x => x.GetInterfaces())
-                .Where(IsGenericRebusHandler)
-                .SelectMany(x => x.GenericTypeArguments)
-                .Distinct();
-        }
-        private bool IsGenericRebusHandler(Type t)
-        {
-            return t.IsGenericType && t.GetGenericTypeDefinition() == typeof(IHandleMessages<>);
-        }
-
-        /// <summary>
         /// Sends an unsubscription request for <typeparamref name="TEvent"/> to the destination as
         /// specified by the currently used implementation of <see cref="IDetermineMessageOwnership"/>.
         /// </summary>

--- a/src/Rebus/Bus/RebusBus.cs
+++ b/src/Rebus/Bus/RebusBus.cs
@@ -314,15 +314,15 @@ namespace Rebus.Bus
         /// </summary>
         public void SubscribeForAssemblyHandlers(params Assembly[] assemblies)
         {
-            foreach (var messageType in assemblies.SelectMany(GetTypesOfMessagesHandledByRebus))
+            foreach (var messageType in GetTypesOfMessagesHandledByRebus(assemblies))
             {
                 Subscribe(messageType);
             }
         }
 
-        private IEnumerable<Type> GetTypesOfMessagesHandledByRebus(Assembly assembly)
+        private IEnumerable<Type> GetTypesOfMessagesHandledByRebus(Assembly[] assemblies)
         {
-            return assembly.GetTypes()
+            return assemblies.SelectMany(x => x.GetTypes())
                 .SelectMany(x => x.GetInterfaces())
                 .Where(IsGenericRebusHandler)
                 .SelectMany(x => x.GenericTypeArguments)

--- a/src/Rebus/Bus/RebusBus.cs
+++ b/src/Rebus/Bus/RebusBus.cs
@@ -312,7 +312,7 @@ namespace Rebus.Bus
         /// Scans the assemblies supplied in <paramref name="assemblies"/> for handlers that implement 
         /// <see cref="IHandleMessages{TMessage}"/> and adds a subscription for the handled message types.
         /// </summary>
-        public void SubscribeForAssemblyHandlers(params Assembly[] assemblies)
+        public void SubscribeByScanningForHandlers(params Assembly[] assemblies)
         {
             foreach (var messageType in GetTypesOfMessagesHandledByRebus(assemblies))
             {


### PR DESCRIPTION
Added the ability to automatically scan assemblies for message handlers and to add corresponding subscriptions.  Looks like this:

    bus.SubscribeByScanningForHandlers(assembly1, assembly2);