### PR TITLE
Add support for the async version of IAmInitiatedBy 

### DIFF
--- a/src/Rebus/Bus/Dispatcher.cs
+++ b/src/Rebus/Bus/Dispatcher.cs
@@ -263,7 +263,7 @@ This most likely indicates that you have configured this Rebus service to use an
 
                 if (sagaData == null)
                 {
-                    if (handler is IAmInitiatedBy<TMessage>)
+                    if (handler is IAmInitiatedBy<TMessage> || handler is IAmInitiatedByAsync<TMessage>)
                     {
                         saga.IsNew = true;
                         saga.Complete = false;

--- a/src/Rebus/IAmInitiatedBy.cs
+++ b/src/Rebus/IAmInitiatedBy.cs
@@ -8,4 +8,8 @@ namespace Rebus
     public interface IAmInitiatedBy<TMessage> : IHandleMessages<TMessage>
     {
     }
+
+    public interface IAmInitiatedByAsync<TMessage> : IHandleMessagesAsync<TMessage>
+    {
+    }
 }


### PR DESCRIPTION
With this, the Saga supports async handlers also for initiation.

It's now possible to write:

```
    class SomeSaga : Saga<SomeSagaData>,
             IAmInitiatedByAsync<SomeAsyncMessage>,
             IHandleMessagesAsync<SomeOtherAsyncMessage>
```