### PR TITLE
Fix ASB multiple message receive in the same transaction

### DIFF
--- a/src/Rebus.AzureServiceBus/AzureServiceBusMessageQueue.cs
+++ b/src/Rebus.AzureServiceBus/AzureServiceBusMessageQueue.cs
@@ -196,7 +196,6 @@ namespace Rebus.AzureServiceBus
                         }
 
                         context[AzureServiceBusReceivedMessage] = brokeredMessage;
-                        context[AzureServiceBusMessageBatch] = new List<Tuple<string, Envelope>>();
 
                         // inject method into message context to allow for long-running message handling operations to have their lock renewed
                         var peekLockRenewalAction = (Action)(() => RenewPeekLock(context, messageId));
@@ -398,7 +397,7 @@ namespace Rebus.AzureServiceBus
                     .Select(seconds => TimeSpan.FromSeconds(seconds))
                     .ToArray();
 
-                if (messagesToSend.Any())
+                if (messagesToSend != null && messagesToSend.Any())
                 {
                     var messagesForEachRecipient = messagesToSend
                         .GroupBy(g => g.Item1)


### PR DESCRIPTION
When receiving multiple messages in the same transaction context, the ASB transport would fail because it was doing the following on each receive.

````
if (context[AzureServiceBusMessageBatch] != null)
    throw [...];

context[AzureServiceBusMessageBatch] = new List<Tuple<string, Envelope>>();
````

I triggered this bug while testing the ReturnToSourceQueue.AzureServiceBus tool.

For safeness, I added a check not to fail on commit when no messages haven't been enqueued but the commit has been called. I can remove this bit if you prefer.

I've see no tests section regarding receiving multiple messages in the same transaction. Did I missed them?
