### PR TITLE
Switch SQL Server implementations to use IDbconnectionProvider

### DIFF
--- a/Rebus/Persistence/SqlServer/SqlServerSagaStorage.cs
+++ b/Rebus/Persistence/SqlServer/SqlServerSagaStorage.cs
@@ -31,7 +31,7 @@ namespace Rebus.Persistence.SqlServer
         static readonly JsonSerializerSettings Settings =
             new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All };
 
-        readonly DbConnectionProvider _connectionProvider;
+		readonly IDbConnectionProvider _connectionProvider;
         readonly string _dataTableName;
         readonly string _indexTableName;
         readonly string _idPropertyName = Reflect.Path<ISagaData>(d => d.Id);
@@ -40,7 +40,7 @@ namespace Rebus.Persistence.SqlServer
         /// <summary>
         /// Constructs the saga storage, using the specified connection provider and tables for persistence.
         /// </summary>
-        public SqlServerSagaStorage(DbConnectionProvider connectionProvider, string dataTableName, string indexTableName)
+		public SqlServerSagaStorage(IDbConnectionProvider connectionProvider, string dataTableName, string indexTableName)
         {
             _connectionProvider = connectionProvider;
             _dataTableName = dataTableName;

--- a/Rebus/Persistence/SqlServer/SqlServerSubscriptionStorage.cs
+++ b/Rebus/Persistence/SqlServer/SqlServerSubscriptionStorage.cs
@@ -20,7 +20,7 @@ namespace Rebus.Persistence.SqlServer
             RebusLoggerFactory.Changed += f => _log = f.GetCurrentClassLogger();
         }
 
-        readonly DbConnectionProvider _connectionProvider;
+		readonly IDbConnectionProvider _connectionProvider;
         readonly string _tableName;
 
         /// <summary>
@@ -28,7 +28,7 @@ namespace Rebus.Persistence.SqlServer
         /// storage is shared by all subscribers and publishers, the <paramref name="isCentralized"/> parameter can be set to true
         /// in order to subscribe/unsubscribe directly instead of sending subscription/unsubscription requests
         /// </summary>
-        public SqlServerSubscriptionStorage(DbConnectionProvider connectionProvider, string tableName, bool isCentralized)
+        public SqlServerSubscriptionStorage(IDbConnectionProvider connectionProvider, string tableName, bool isCentralized)
         {
 
             IsCentralized = isCentralized;

--- a/Rebus/Persistence/SqlServer/SqlServerTimeoutManager.cs
+++ b/Rebus/Persistence/SqlServer/SqlServerTimeoutManager.cs
@@ -22,14 +22,14 @@ namespace Rebus.Persistence.SqlServer
             RebusLoggerFactory.Changed += f => _log = f.GetCurrentClassLogger();
         }
 
-        readonly DbConnectionProvider _connectionProvider;
+        readonly IDbConnectionProvider _connectionProvider;
         readonly string _tableName;
         readonly JsonSerializerSettings _headerSerializationSettings = new JsonSerializerSettings();
 
         /// <summary>
         /// Constructs the timeout manager, using the specified connection provider and table to store the messages until they're due.
         /// </summary>
-        public SqlServerTimeoutManager(DbConnectionProvider connectionProvider, string tableName)
+        public SqlServerTimeoutManager(IDbConnectionProvider connectionProvider, string tableName)
         {
             _connectionProvider = connectionProvider;
             _tableName = tableName;


### PR DESCRIPTION
Currently `SqlServerTransport` makes use of an `IDbConnectionProvider` however `SqlServerSagaStorage`, `SqlServerSubscriptionStorage` and `SqlServerTimeoutManager` all make use of the concrete `DbConnectionProvider`. This quick patch relaxes this so that they all make use of `IDbConnectionProvider` instead to allow consumer to provide their own implementations of `IDbConnectionProvider`.