### PR TITLE
Add Type to SqlServerTransport

### DIFF
--- a/Rebus/Transport/SqlServer/SqlServerTransport.cs
+++ b/Rebus/Transport/SqlServer/SqlServerTransport.cs
@@ -130,6 +130,7 @@ CREATE TABLE [dbo].[{0}]
 (
 	[id] [bigint] IDENTITY(1,1) NOT NULL,
 	[recipient] [nvarchar](200) NOT NULL,
+	[type] [nvarchar](max) NULL,
 	[priority] [int] NOT NULL,
     [expiration] [datetime2] NOT NULL,
     [visible] [datetime2] NOT NULL,
@@ -196,6 +197,7 @@ CREATE NONCLUSTERED INDEX [IDX_EXPIRATION_{0}] ON [dbo].[{0}]
 INSERT INTO [{0}]
 (
     [recipient],
+	[type],
     [headers],
     [body],
     [priority],
@@ -205,6 +207,7 @@ INSERT INTO [{0}]
 VALUES
 (
     @recipient,
+	@type,
     @headers,
     @body,
     @priority,
@@ -214,6 +217,8 @@ VALUES
                     _tableName);
 
                 var headers = message.Headers.Clone();
+	            var messageType = string.Empty;
+	            headers.TryGetValue(Headers.Type, out messageType);
 
                 var priority = GetMessagePriority(headers);
                 var initialVisibilityDelay = GetInitialVisibilityDelay(headers);
@@ -223,6 +228,7 @@ VALUES
                 var serializedHeaders = _headerSerializer.Serialize(headers);
 
                 command.Parameters.Add("recipient", SqlDbType.NVarChar, RecipientColumnSize).Value = destinationAddress;
+	            command.Parameters.Add("type", SqlDbType.NVarChar).Value = messageType;
                 command.Parameters.Add("headers", SqlDbType.VarBinary).Value = serializedHeaders;
                 command.Parameters.Add("body", SqlDbType.VarBinary).Value = message.Body;
                 command.Parameters.Add("priority", SqlDbType.Int).Value = priority;

--- a/Rebus/Transport/SqlServer/SqlServerTransport.cs
+++ b/Rebus/Transport/SqlServer/SqlServerTransport.cs
@@ -356,7 +356,7 @@ VALUES
             }
         }
 
-        class HeaderSerializer
+        public class HeaderSerializer
         {
             static readonly Encoding DefaultEncoding = Encoding.UTF8;
 


### PR DESCRIPTION
Two fairly minor changes;
 1. Add Type to the message table. This is extracted from the headers and persisted here. It's not used by Rebus but is very helpful for queue introspection and monitoring
 2. Along the same lines; re-made `HeaderSerializer` public (we again use it to extract some properties from the messages as part of our dashboarding). I imagine the long term solution would have some sort of generic serializer instance you can retrieve through the API? But I'm not sure how that would work with other transports.