### PR TITLE
Fix for using remote MSMQ

### DIFF
--- a/Rebus/Transport/Msmq/MsmqTransport.cs
+++ b/Rebus/Transport/Msmq/MsmqTransport.cs
@@ -306,11 +306,19 @@ namespace Rebus.Transport.Msmq
             {
                 if (_inputQueue != null) return _inputQueue;
 
-                var inputQueuePath = MsmqUtil.GetPath(_inputQueueName);
+                string inputQueuePath;
 
-                MsmqUtil.EnsureQueueExists(inputQueuePath, _log);
+                if (MsmqUtil.IsLocal(_inputQueueName))
+                {
+                    inputQueuePath = MsmqUtil.GetPath(_inputQueueName);
 
-                MsmqUtil.EnsureMessageQueueIsTransactional(inputQueuePath);
+                    MsmqUtil.EnsureQueueExists(inputQueuePath, _log);
+                    MsmqUtil.EnsureMessageQueueIsTransactional(inputQueuePath);
+                }
+                else
+                {
+                    inputQueuePath = MsmqUtil.GetFullPath(_inputQueueName);
+                }
 
                 _inputQueue = new MessageQueue(inputQueuePath, QueueAccessMode.SendAndReceive)
                 {


### PR DESCRIPTION
I had an issue with using an MSMQ on a remote machine, because when getting the queue I believe always a local path is used which is then checked for existence and whether it is transactional.

I've changed how the MSMQ path is resolved based on whether it's local or remote, so we get the full path for a remote queue. For a local queue everything is the same as before but for a remote one we don't try to do the existence and transctionality checks because they don't work (they throw: `System.Messaging.MessageQueueException: The specified format name does not support the requested operation. For example, a direct queue format name cannot be deleted.`)