### PR TITLE
Convention based subscriptions.

### DIFF
--- a/Rebus.Tests/Contracts/Activation/ContainerTests.cs
+++ b/Rebus.Tests/Contracts/Activation/ContainerTests.cs
@@ -139,9 +139,19 @@ namespace Rebus.Tests.Contracts.Activation
                 return _bus.Subscribe<TEvent>();
             }
 
+            public Task Subscribe(Type eventType)
+            {
+                return _bus.Subscribe(eventType);
+            }
+
             public Task Unsubscribe<TEvent>()
             {
                 return _bus.Unsubscribe<TEvent>();
+            }
+
+            public Task Unsubscribe(Type eventType)
+            {
+                return _bus.Unsubscribe(eventType);
             }
 
             public Task Publish(object eventMessage, Dictionary<string, string> optionalHeaders = null)
@@ -229,7 +239,17 @@ namespace Rebus.Tests.Contracts.Activation
                 throw new NotImplementedException();
             }
 
+            public Task Subscribe(Type eventType)
+            {
+                throw new NotImplementedException();
+            }
+
             public Task Unsubscribe<TEvent>()
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task Unsubscribe(Type eventType)
             {
                 throw new NotImplementedException();
             }

--- a/Rebus/Bus/IBus.cs
+++ b/Rebus/Bus/IBus.cs
@@ -55,9 +55,29 @@ namespace Rebus.Bus
         Task Subscribe<TEvent>();
 
         /// <summary>
+        /// Subscribes to the topic defined by the assembly-qualified name of <paramref name="eventType"/>. 
+        /// While this kind of subscription can work universally with the general topic-based routing, it works especially well with type-based routing,
+        /// which can be enabled by going 
+        /// <code>
+        /// Configure.With(...)
+        ///     .(...)
+        ///     .Routing(r => r.TypeBased()
+        ///             .Map&lt;SomeMessage&gt;("someEndpoint")
+        ///             .(...))
+        /// </code>
+        /// in the configuration
+        /// </summary>
+        Task Subscribe(Type eventType);
+
+        /// <summary>
         /// Unsubscribes from the topic defined by the assembly-qualified name of <typeparamref name="TEvent"/>
         /// </summary>
         Task Unsubscribe<TEvent>();
+        
+        /// <summary>
+        /// Unsubscribes from the topic defined by the assembly-qualified name of <paramref name="eventType"/>
+        /// </summary>
+        Task Unsubscribe(Type eventType);
 
         /// <summary>
         /// Publishes the event message on the topic defined by the assembly-qualified name of the type of the message.

--- a/Rebus/Bus/RebusBus.cs
+++ b/Rebus/Bus/RebusBus.cs
@@ -150,7 +150,25 @@ namespace Rebus.Bus
         /// </summary>
         public Task Subscribe<TEvent>()
         {
-            var topic = typeof(TEvent).GetSimpleAssemblyQualifiedName();
+            return Subscribe(typeof(TEvent));
+        }
+
+        /// <summary>
+        /// Subscribes to the topic defined by the assembly-qualified name of <paramref name="eventType"/>. 
+        /// While this kind of subscription can work universally with the general topic-based routing, it works especially well with type-based routing,
+        /// which can be enabled by going 
+        /// <code>
+        /// Configure.With(...)
+        ///     .(...)
+        ///     .Routing(r => r.TypeBased()
+        ///             .Map&lt;SomeMessage&gt;("someEndpoint")
+        ///             .(...))
+        /// </code>
+        /// in the configuration
+        /// </summary>
+        public Task Subscribe(Type eventType)
+        {
+            var topic = eventType.GetSimpleAssemblyQualifiedName();
 
             return InnerSubscribe(topic);
         }
@@ -160,7 +178,15 @@ namespace Rebus.Bus
         /// </summary>
         public Task Unsubscribe<TEvent>()
         {
-            var topic = typeof(TEvent).GetSimpleAssemblyQualifiedName();
+            return Unsubscribe(typeof(TEvent));
+        }
+
+        /// <summary>
+        /// Unsubscribes from the topic defined by the assembly-qualified name of <paramref name="eventType"/>
+        /// </summary>
+        public Task Unsubscribe(Type eventType)
+        {
+            var topic = eventType.GetSimpleAssemblyQualifiedName();
 
             return InnerUnsubscribe(topic);
         }

--- a/Rebus/Config/OneWayClientBusDecorator.cs
+++ b/Rebus/Config/OneWayClientBusDecorator.cs
@@ -50,9 +50,19 @@ namespace Rebus.Config
             return _innerBus.Subscribe<TEvent>();
         }
 
+        public Task Subscribe(Type eventType)
+        {
+            return _innerBus.Subscribe(eventType);
+        }
+
         public Task Unsubscribe<TEvent>()
         {
             return _innerBus.Unsubscribe<TEvent>();
+        }
+
+        public Task Unsubscribe(Type eventType)
+        {
+            return _innerBus.Unsubscribe(eventType);
         }
 
         public Task Publish(object eventMessage, Dictionary<string, string> optionalHeaders = null)


### PR DESCRIPTION
Added Subscribe / Unsubscribe overloads to allow for convention based subscriptions.

Hit a situation today where I wanted to subscribe all event based messages that were being handled, had to use refection to achieve this.

```
foreach (var eventType in eventTypes)
{
    var method = bus.GetType().GetMethod("Subscribe");
    var generic = method.MakeGenericMethod(messageType);
    var task = (Task)generic.Invoke(bus, null);
    task.Wait();
}
```

This will allow for easier convention based subscriptions.