### PR TITLE
Found a nice bug, with the AmazonSQS SendMessageBatchAsync

### DIFF
--- a/Rebus.AmazonSQS/AmazonSQSTransport.cs
+++ b/Rebus.AmazonSQS/AmazonSQSTransport.cs
@@ -222,7 +222,13 @@ namespace Rebus.AmazonSQS
 
                         var request = new SendMessageBatchRequest(destinationUrl, entries);
 
-                        await client.SendMessageBatchAsync(request);
+                        var response = await client.SendMessageBatchAsync(request);
+
+                        if (response.Failed.Any())
+                        {
+                            var failed = response.Failed.Select(f => new AmazonSQSException($"Failed {f.Message} with Id={f.Id}, Code={f.Code}, SenderFault={f.SenderFault}")).ToArray();
+                            throw new AggregateException(failed);
+                        }
                     })
 
                 );

--- a/Rebus.Tests/Contracts/Transports/MessageExpiration.cs
+++ b/Rebus.Tests/Contracts/Transports/MessageExpiration.cs
@@ -123,7 +123,7 @@ namespace Rebus.Tests.Contracts.Transports
 
         static byte[] DontCareAboutTheBody()
         {
-            return new byte[] { 1, 2, 3 };
+            return System.Text.Encoding.UTF8.GetBytes("Dont Care About The Body");
         }
     }
 }


### PR DESCRIPTION
SendMessageBatchAsync doesn't throw any exceptions, you need to look at the failed collection to see the failures, not sure what would happen by throwing an aggregate exception or what the recovery process would be.

I guess this is to start a discussion how to fix this issue.