### PR TITLE
Some enhancements to Rebus.Autofac

### DIFF
--- a/Rebus.Autofac/AutofacContainerAdapterExtentions.cs
+++ b/Rebus.Autofac/AutofacContainerAdapterExtentions.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Autofac;
+using Rebus.Pipeline;
+
+namespace Rebus.Autofac
+{
+    public static class AutofacContainerAdapterExtentions
+    {
+        public static void RegisterRebus(this ContainerBuilder self)
+        {
+            self
+                .Register(c =>
+                {
+                    var currentMessageContext = MessageContext.Current;
+                    if (currentMessageContext == null)
+                    {
+                        throw new InvalidOperationException("Attempted to inject the current message context from MessageContext.Current, but it was null! Did you attempt to resolve IMessageContext from outside of a Rebus message handler?");
+                    }
+                    return currentMessageContext;
+                })
+                .InstancePerDependency()
+                .ExternallyOwned();
+        }
+    }
+}

--- a/Rebus.Autofac/Rebus.Autofac.csproj
+++ b/Rebus.Autofac/Rebus.Autofac.csproj
@@ -44,6 +44,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AutofacContainerAdapter.cs" />
+    <Compile Include="AutofacContainerAdapterExtentions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
- Allows you to register `AutofacContainerAdapter` with a `LifetimeScope`
- Added a key to allow to resolve handlers based on the provided key.
- If you register using a `LifetimeScope` it will not update the container, you have to call builder.RegisterRebus(). (updating an autofac container should be avoided if possible) 