### PR TITLE
Added outgoing correlation id to Serilog log context.

### DIFF
--- a/Rebus.Serilog.Tests/Properties/AssemblyInfo.cs
+++ b/Rebus.Serilog.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Rebus.Serilog.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Rebus.Serilog.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("48fa32d8-bdf1-492d-a9f8-16c3cbae39e3")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Rebus.Serilog.Tests/Rebus.Serilog.Tests.csproj
+++ b/Rebus.Serilog.Tests/Rebus.Serilog.Tests.csproj
@@ -1,0 +1,85 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{48FA32D8-BDF1-492D-A9F8-16C3CBAE39E3}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Rebus.Serilog.Tests</RootNamespace>
+    <AssemblyName>Rebus.Serilog.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.1.5.1\lib\net45\Serilog.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Serilog.FullNetFx, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.1.5.1\lib\net45\Serilog.FullNetFx.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="RebusCorrelationIdEnricherTests.cs" />
+    <Compile Include="Support\DelegatingSink.cs" />
+    <Compile Include="Support\Extensions.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Rebus.Serilog\Rebus.Serilog.csproj">
+      <Project>{3ceef673-4e4f-4057-8c14-3d83f024e8a7}</Project>
+      <Name>Rebus.Serilog</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Rebus.Tests\Rebus.Tests.csproj">
+      <Project>{959c65ab-d21a-4582-bc4f-06d1425ff274}</Project>
+      <Name>Rebus.Tests</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Rebus\Rebus.csproj">
+      <Project>{7d7b7b36-6298-4e85-9a0e-1b415c5b9d12}</Project>
+      <Name>Rebus</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Rebus.Serilog.Tests/RebusCorrelationIdEnricherTests.cs
+++ b/Rebus.Serilog.Tests/RebusCorrelationIdEnricherTests.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Rebus.Activation;
+using Rebus.Config;
+using Rebus.Messages;
+using Rebus.Serilog.Tests.Support;
+using Rebus.Tests;
+using Rebus.Transport.InMem;
+using Serilog;
+using Serilog.Events;
+
+namespace Rebus.Serilog.Tests
+{
+    public class RebusCorrelationIdEnricherTests : FixtureBase
+    {
+        [Test]
+        public void IncludesCorrelationIdInEventProperties()
+        {
+            LogEvent evt = null;
+            
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Is(LogEventLevel.Debug)
+                .Enrich.FromLogContext()
+                .Enrich.WithMachineName()
+                .Enrich.WithThreadId()
+                .Enrich.WithProcessId()
+                .Enrich.WithRebusCorrelationId(Headers.CorrelationId)
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            var activator = new BuiltinHandlerActivator();
+            
+            Configure.With(activator)
+                .Transport(t => t.UseInMemoryTransport(new InMemNetwork(), "input"))
+                .Logging(l => l.Serilog(Log.Logger))
+                .Options(o => o.LogPipeline(true))
+                .Start();
+
+            var counter = new SharedCounter(1);
+
+            Using(counter);
+
+            activator.Handle<DateTime>(timestamp => 
+            {
+                Assert.NotNull(evt);
+
+                var correlationId = (string)evt.Properties[Headers.CorrelationId].LiteralValue();
+                Assert.AreEqual("known-correlation-id", correlationId);
+
+                counter.Decrement();
+
+                return Task.FromResult(0);
+            });
+
+            var headers = new Dictionary<string, string>
+            {
+                { Headers.CorrelationId, "known-correlation-id" }
+            };
+
+            activator.Bus.SendLocal(DateTime.UtcNow, headers).Wait();
+
+            counter.WaitForResetEvent(10);
+        }
+    }
+}

--- a/Rebus.Serilog.Tests/Support/DelegatingSink.cs
+++ b/Rebus.Serilog.Tests/Support/DelegatingSink.cs
@@ -1,0 +1,34 @@
+using System;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Rebus.Serilog.Tests.Support
+{
+    public class DelegatingSink : ILogEventSink
+    {
+        readonly Action<LogEvent> _write;
+
+        public DelegatingSink(Action<LogEvent> write)
+        {
+            if (write == null) throw new ArgumentNullException(nameof(write));
+            _write = write;
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            _write(logEvent);
+        }
+
+        public static LogEvent GetLogEvent(Action<ILogger> writeAction)
+        {
+            LogEvent result = null;
+            var l = new LoggerConfiguration()
+                .WriteTo.Sink(new DelegatingSink(le => result = le))
+                .CreateLogger();
+
+            writeAction(l);
+            return result;
+        }
+    }
+}

--- a/Rebus.Serilog.Tests/Support/Extensions.cs
+++ b/Rebus.Serilog.Tests/Support/Extensions.cs
@@ -1,0 +1,12 @@
+﻿using Serilog.Events;
+
+namespace Rebus.Serilog.Tests.Support
+{
+    public static class Extensions
+    {
+        public static object LiteralValue(this LogEventPropertyValue @this)
+        {
+            return ((ScalarValue)@this).Value;
+        }
+    }
+}

--- a/Rebus.Serilog.Tests/packages.config
+++ b/Rebus.Serilog.Tests/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="2.6.4" targetFramework="net452" />
+  <package id="Serilog" version="1.5.1" targetFramework="net452" />
+</packages>

--- a/Rebus/Bus/RebusBus.cs
+++ b/Rebus/Bus/RebusBus.cs
@@ -372,11 +372,13 @@ namespace Rebus.Bus
             }
             else
             {
-                using (var context = new DefaultTransactionContext())
+                using (var transactionContext = new DefaultTransactionContext())
                 {
-                    await SendUsingTransactionContext(destinationAddresses, logicalMessage, context);
+                    AmbientTransactionContext.Current = transactionContext;
 
-                    await context.Complete();
+                    await SendUsingTransactionContext(destinationAddresses, logicalMessage, transactionContext);
+
+                    await transactionContext.Complete();
                 }
             }
         }

--- a/Rebus/Pipeline/OutgoingStepContext.cs
+++ b/Rebus/Pipeline/OutgoingStepContext.cs
@@ -17,6 +17,8 @@ namespace Rebus.Pipeline
             Save(logicalMessage);
             Save(destinationAddresses);
             Save(transactionContext);
+
+            transactionContext.Items["outgoingStepContext"] = this;
         }
     }
 }

--- a/Rebus2.sln
+++ b/Rebus2.sln
@@ -188,6 +188,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rebus.UnitOfWork", "Rebus.U
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rebus.UnitOfWork.Tests", "Rebus.UnitOfWork.Tests\Rebus.UnitOfWork.Tests.csproj", "{A3EDE74E-E9E2-431C-830C-3FFE7EF5B1FF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rebus.Serilog.Tests", "Rebus.Serilog.Tests\Rebus.Serilog.Tests.csproj", "{48FA32D8-BDF1-492D-A9F8-16C3CBAE39E3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -402,6 +404,10 @@ Global
 		{A3EDE74E-E9E2-431C-830C-3FFE7EF5B1FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A3EDE74E-E9E2-431C-830C-3FFE7EF5B1FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A3EDE74E-E9E2-431C-830C-3FFE7EF5B1FF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{48FA32D8-BDF1-492D-A9F8-16C3CBAE39E3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{48FA32D8-BDF1-492D-A9F8-16C3CBAE39E3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{48FA32D8-BDF1-492D-A9F8-16C3CBAE39E3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{48FA32D8-BDF1-492D-A9F8-16C3CBAE39E3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -490,5 +496,6 @@ Global
 		{0C2E55EA-8A27-44B5-8BC4-F7B73E1950A7} = {A54FE4CB-BB06-4198-8B4D-3EBD7152045B}
 		{E77B5611-DA49-4977-BD69-C413A5D4221B} = {0C2E55EA-8A27-44B5-8BC4-F7B73E1950A7}
 		{A3EDE74E-E9E2-431C-830C-3FFE7EF5B1FF} = {0C2E55EA-8A27-44B5-8BC4-F7B73E1950A7}
+		{48FA32D8-BDF1-492D-A9F8-16C3CBAE39E3} = {0CC2D01C-9007-45A0-8B35-0CB40C171E25}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Found an issue with serilog / seq couldn't see a correlation id on the initial sent message, everything after the message was received had the correct correlation id.

I have ran all the local tests and all the tests passed.