### PR TITLE
Now possible to run bus as readonly on ASB (basic)

### DIFF
--- a/Rebus.AzureServiceBus.Tests/BasicAzureServiceBusBasicReceiveOnly.cs
+++ b/Rebus.AzureServiceBus.Tests/BasicAzureServiceBusBasicReceiveOnly.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Rebus.Activation;
+using Rebus.AzureServiceBus.Config;
+using Rebus.AzureServiceBus.Tests.Factories;
+using Rebus.Bus;
+using Rebus.Config;
+using Rebus.Logging;
+using Rebus.Routing.TypeBased;
+using Rebus.Tests;
+using Rebus.Tests.Extensions;
+using Rebus.Threading.TaskParallelLibrary;
+
+namespace Rebus.AzureServiceBus.Tests
+{
+    [TestFixture, Category(TestCategory.Azure)]
+    public class BasicAzureServiceBusBasicReceiveOnly : FixtureBase
+    {
+        readonly AzureServiceBusMode _azureServiceBusMode;
+        static readonly string QueueName = TestConfig.QueueName("input");
+        IBus _receiverBus;
+        IBus _senderBus;
+        AzureServiceBusTransport _transport;
+        BuiltinHandlerActivator _recieverActivator;
+        BuiltinHandlerActivator _senderActivator;
+        protected override void SetUp()
+        {
+            var consoleLoggerFactory = new ConsoleLoggerFactory(false);
+            _transport = new AzureServiceBusTransport(StandardAzureServiceBusTransportFactory.ConnectionString, QueueName, consoleLoggerFactory, new TplAsyncTaskFactory(consoleLoggerFactory));
+            _transport.PurgeInputQueue();
+            //Create the queue for the receiver since it cannot create it self beacuse of lacking rights on the namespace
+            _transport.CreateQueue(QueueName);
+
+            _recieverActivator = new BuiltinHandlerActivator();
+            _senderActivator = new BuiltinHandlerActivator();
+
+            _receiverBus = Configure.With(_recieverActivator)
+                    .Logging(l => l.ColoredConsole())
+                    .Transport(t => t.UseAzureServiceBusAsReadOnly(StandardAzureServiceBusTransportFactory.ConnectionString, QueueName))
+                    .Start();
+
+            _senderBus = Configure.With(_senderActivator)
+                .Transport(t => t.UseAzureServiceBus(StandardAzureServiceBusTransportFactory.ConnectionString, "sender", AzureServiceBusMode.Basic))
+                .Start();
+
+            Using(_receiverBus);
+            Using(_senderBus);
+        }
+
+        [Test]
+        [ExpectedException(typeof(NotSupportedException), ExpectedMessage = "Not able to send. The bus is configured as receiveonly")]
+        public async Task ShouldNotBeAbleToSend()
+        {
+            await _receiverBus.Advanced.Routing.Send("test", "message");
+        }
+
+        [Test]
+        public async void ShouldBeAbleToRecieve()
+        {
+            var gotMessage = new ManualResetEvent(false);
+
+            _recieverActivator.Handle<string>(async (bus, context, message) =>
+            {
+                gotMessage.Set();
+                Console.WriteLine("got message in readonly mode");
+            });
+            await _senderBus.Advanced.Routing.Send(QueueName, "message to receiver");
+
+            gotMessage.WaitOrDie(TimeSpan.FromSeconds(10));
+
+
+        }
+    }
+}

--- a/Rebus.AzureServiceBus.Tests/Rebus.AzureServiceBus.Tests.csproj
+++ b/Rebus.AzureServiceBus.Tests/Rebus.AzureServiceBus.Tests.csproj
@@ -59,6 +59,7 @@
   <ItemGroup>
     <Compile Include="AzureServiceBusBasicSendReceive.cs" />
     <Compile Include="AzureServiceBusContentTypeTest.cs" />
+    <Compile Include="BasicAzureServiceBusBasicReceiveOnly.cs" />
     <Compile Include="Factories\AzureServiceBusBusFactory.cs" />
     <Compile Include="AzureServiceBusManyMessages.cs" />
     <Compile Include="AzureServiceBusMessageExpiration.cs" />

--- a/Rebus.AzureServiceBus/BasicReadOnlyAzureServiceBusTransport.cs
+++ b/Rebus.AzureServiceBus/BasicReadOnlyAzureServiceBusTransport.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading.Tasks;
+using Rebus.Logging;
+using Rebus.Messages;
+using Rebus.Threading;
+using Rebus.Transport;
+
+namespace Rebus.AzureServiceBus
+{
+    public class BasicReadOnlyAzureServiceBusTransport : BasicAzureServiceBusTransport
+    {
+        public BasicReadOnlyAzureServiceBusTransport(string connectionString, string inputQueueAddress, IRebusLoggerFactory rebusLoggerFactory, IAsyncTaskFactory asyncTaskFactory) : base(connectionString, inputQueueAddress, rebusLoggerFactory, asyncTaskFactory)
+        {
+        }
+
+        public override void Initialize()
+        {
+            Log.Info("Initializing Azure Service Bus transport with queue '{0}'", InputQueueAddress);
+        }
+
+        public override Task Send(string destinationAddress, TransportMessage message, ITransactionContext context)
+        {
+            throw new NotSupportedException("Not able to send. The bus is configured as receiveonly");
+        }
+    }
+}

--- a/Rebus.AzureServiceBus/Config/AzureServiceBusConfigurationExtensions.cs
+++ b/Rebus.AzureServiceBus/Config/AzureServiceBusConfigurationExtensions.cs
@@ -58,7 +58,10 @@ namespace Rebus.Config
 
             OneWayClientBackdoor.ConfigureOneWayClient(configurer);
         }
-
+        /// <summary>
+        /// Configures Rebus to use Azure Service Bus to transport messages as a one-way receiving client (i.e. will not be able to send any messages)
+        /// (This enables the option to use a SAS key which only has read rights on the queue and no rights on the namespace itself)
+        /// </summary>
         public static AzureServiceBusTransportSettings UseAzureServiceBusAsReadOnly(
             this StandardConfigurer<ITransport> configurer, string connectionStringNameOrConnectionString,
             string inputQueueAddress)

--- a/Rebus.AzureServiceBus/Rebus.AzureServiceBus.csproj
+++ b/Rebus.AzureServiceBus/Rebus.AzureServiceBus.csproj
@@ -53,6 +53,7 @@
     <Compile Include="AsbStringExtensions.cs" />
     <Compile Include="AzureServiceBusTransport.cs" />
     <Compile Include="BasicAzureServiceBusTransport.cs" />
+    <Compile Include="BasicReadOnlyAzureServiceBusTransport.cs" />
     <Compile Include="Config\AzureServiceBusConfigurationExtensions.cs" />
     <Compile Include="Config\AzureServiceBusMode.cs" />
     <Compile Include="Config\AzureServiceBusTransportSettings.cs" />


### PR DESCRIPTION
This enables the option to use a SAS key which only has read rights on the queue and no rights on the namespace itself