### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Moreover - since the wiki actually contains quite a bit of content - please be p
 
 ![Bedford OB](https://raw.githubusercontent.com/rebus-org/Rebus/master/artwork/little_rebusbus2_copy-200x200.png)
 
-[![install from nuget](http://img.shields.io/nuget/v/Rebus.svg?style=flat-square)](https://www.nuget.org/packages/Rebus)[![downloads](http://img.shields.io/nuget/dt/Rebus.svg?style=flat-square)](https://www.nuget.org/packages/Rebus)
+[![install from nuget](https://img.shields.io/nuget/v/Rebus.svg?style=flat-square)](https://www.nuget.org/packages/Rebus)[![downloads](http://img.shields.io/nuget/dt/Rebus.svg?style=flat-square)](https://www.nuget.org/packages/Rebus)
 
 
 What?
@@ -80,9 +80,9 @@ License
 
 Rebus is licensed under [The MIT License (MIT)][1]. Basically, this license grants you the right to use Rebus in any way you see fit. See [LICENSE.md](/LICENSE.md) for more info.
 
-[1]: http://opensource.org/licenses/MIT
-[2]: http://twitter.com/#!/mookid8000
-[3]: http://nservicebus.com/
+[1]: https://opensource.org/licenses/MIT
+[2]: https://twitter.com/#!/mookid8000
+[3]: http://particular.net
 [4]: http://masstransit-project.com/
-[5]: https://github.com/mookid8000/Rebus/wiki
+[5]: https://github.com/rebus-org/Rebus/wiki
 [6]: http://mookid.dk/oncode/rebus

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Rebus is licensed under [The MIT License (MIT)][1]. Basically, this license gran
 
 [1]: https://opensource.org/licenses/MIT
 [2]: https://twitter.com/#!/mookid8000
-[3]: http://particular.net
+[3]: http://particular.net/nservicebus
 [4]: http://masstransit-project.com/
 [5]: https://github.com/rebus-org/Rebus/wiki
 [6]: http://mookid.dk/oncode/rebus


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/mookid8000/Rebus/wiki | https://github.com/rebus-org/Rebus/wiki 


### HTTPS Corrected URLs 
Was | Now 
--- | --- 
http://img.shields.io/nuget/v/Rebus.svg?style=flat-square | https://img.shields.io/nuget/v/Rebus.svg?style=flat-square 
http://opensource.org/licenses/MIT | https://opensource.org/licenses/MIT 
http://twitter.com/#!/mookid8000 | https://twitter.com/#!/mookid8000 


### Other Corrected URLs 
Was | Now 
--- | --- 
http://nservicebus.com/ | http://particular.net/nservicebus
