### PR TITLE
Now possible to configure whether ASB-queues should be automatically …

### DIFF
--- a/Rebus.AzureServiceBus.Tests/AzureServiceBusDoNotCreateQueue.cs
+++ b/Rebus.AzureServiceBus.Tests/AzureServiceBusDoNotCreateQueue.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.ServiceBus;
+using NUnit.Framework;
+using Rebus.Activation;
+using Rebus.AzureServiceBus.Config;
+using Rebus.AzureServiceBus.Tests.Factories;
+using Rebus.Bus;
+using Rebus.Config;
+using Rebus.Logging;
+using Rebus.Tests;
+using Rebus.Tests.Extensions;
+using Rebus.Threading.TaskParallelLibrary;
+
+namespace Rebus.AzureServiceBus.Tests
+{
+
+
+
+    [TestFixture, Category(TestCategory.Azure)]
+    public class BasicAzureServiceBusBasicReceiveOnly : FixtureBase
+    {
+        
+        static readonly string QueueName = TestConfig.QueueName("input");
+       
+        
+          
+       
+        [Test]
+        [TestCase(AzureServiceBusMode.Basic)]
+        [TestCase(AzureServiceBusMode.Standard)]
+        public async void ShouldBeAbleToRecieveEvenWhenNotCreatingQueue(AzureServiceBusMode mode)
+        {
+            var consoleLoggerFactory = new ConsoleLoggerFactory(false);
+            var transport = new AzureServiceBusTransport(StandardAzureServiceBusTransportFactory.ConnectionString, QueueName, consoleLoggerFactory, new TplAsyncTaskFactory(consoleLoggerFactory));
+            transport.PurgeInputQueue();
+            //Create the queue for the receiver since it cannot create it self beacuse of lacking rights on the namespace
+            transport.CreateQueue(QueueName);
+
+            var recieverActivator = new BuiltinHandlerActivator();
+            var senderActivator = new BuiltinHandlerActivator();
+
+            var receiverBus = Configure.With(recieverActivator)
+                .Logging(l => l.ColoredConsole())
+                .Transport(t =>
+                    t.UseAzureServiceBus(StandardAzureServiceBusTransportFactory.ConnectionString, QueueName)
+                        .DoNotCreateQueues())
+                .Start();
+
+            var senderBus = Configure.With(senderActivator)
+                .Transport(t => t.UseAzureServiceBus(StandardAzureServiceBusTransportFactory.ConnectionString, "sender", mode))
+                .Start();
+
+            Using(receiverBus);
+            Using(senderBus);
+
+            var gotMessage = new ManualResetEvent(false);
+
+            recieverActivator.Handle<string>(async (bus, context, message) =>
+            {
+                gotMessage.Set();
+                Console.WriteLine("got message in readonly mode");
+            });
+            await senderBus.Advanced.Routing.Send(QueueName, "message to receiver");
+
+            gotMessage.WaitOrDie(TimeSpan.FromSeconds(10));
+
+
+        }
+    }
+
+    public class NotCreatingQueueTest : FixtureBase
+    {
+        [TestCase(AzureServiceBusMode.Basic)]
+        [TestCase(AzureServiceBusMode.Standard)]
+        public void ShouldNotCreateInputQueueWhenConfiguredNotTo(AzureServiceBusMode mode)
+        {
+            var manager = NamespaceManager.CreateFromConnectionString(StandardAzureServiceBusTransportFactory.ConnectionString);
+            var queueName = Guid.NewGuid().ToString("N");
+
+            Assert.IsFalse(manager.QueueExists(queueName));
+
+            var recieverActivator = new BuiltinHandlerActivator();
+            var bus = Configure.With(recieverActivator)
+                .Logging(l => l.ColoredConsole())
+                .Transport(t =>
+                    t.UseAzureServiceBus(StandardAzureServiceBusTransportFactory.ConnectionString, queueName, mode)
+                        .DoNotCreateQueues())
+                .Start();
+           
+                Assert.IsFalse(manager.QueueExists(queueName));
+           
+            Using(recieverActivator);
+            Using(bus);
+
+        }
+    }
+}

--- a/Rebus.AzureServiceBus.Tests/Rebus.AzureServiceBus.Tests.csproj
+++ b/Rebus.AzureServiceBus.Tests/Rebus.AzureServiceBus.Tests.csproj
@@ -59,6 +59,7 @@
   <ItemGroup>
     <Compile Include="AzureServiceBusBasicSendReceive.cs" />
     <Compile Include="AzureServiceBusContentTypeTest.cs" />
+    <Compile Include="AzureServiceBusDoNotCreateQueue.cs" />
     <Compile Include="Factories\AzureServiceBusBusFactory.cs" />
     <Compile Include="AzureServiceBusManyMessages.cs" />
     <Compile Include="AzureServiceBusMessageExpiration.cs" />

--- a/Rebus.AzureServiceBus/AzureServiceBusTransport.cs
+++ b/Rebus.AzureServiceBus/AzureServiceBusTransport.cs
@@ -125,6 +125,12 @@ namespace Rebus.AzureServiceBus
 
         public void CreateQueue(string address)
         {
+            if (DoNotCreateQueuesEnabled)
+            {
+                _log.Info("Transport configured to not create queue - skipping existencecheck and potential creation");
+                return;
+            }
+
             if (_namespaceManager.QueueExists(address)) return;
 
             var queueDescription = new QueueDescription(address)
@@ -631,5 +637,7 @@ namespace Rebus.AzureServiceBus
         /// Always returns true because Azure Service Bus topics and subscriptions are global
         /// </summary>
         public bool IsCentralized => true;
+
+        public bool DoNotCreateQueuesEnabled { get; set; }
     }
 }

--- a/Rebus.AzureServiceBus/BasicAzureServiceBusTransport.cs
+++ b/Rebus.AzureServiceBus/BasicAzureServiceBusTransport.cs
@@ -112,6 +112,12 @@ namespace Rebus.AzureServiceBus
 
         public void CreateQueue(string address)
         {
+            if (DoNotCreateQueuesEnabled)
+            {
+                _log.Info("Transport configured to not create queue - skipping existencecheck and potential creation");
+                return;
+            }
+            
             if (_namespaceManager.QueueExists(address)) return;
 
             var queueDescription = new QueueDescription(address)
@@ -416,6 +422,7 @@ namespace Rebus.AzureServiceBus
         }
 
         public bool PartitioningEnabled { get; set; }
+        public bool DoNotCreateQueuesEnabled { get; set; }
 
         public void Dispose()
         {

--- a/Rebus.AzureServiceBus/Config/AzureServiceBusConfigurationExtensions.cs
+++ b/Rebus.AzureServiceBus/Config/AzureServiceBusConfigurationExtensions.cs
@@ -84,7 +84,7 @@ namespace Rebus.Config
                     transport.AutomaticallyRenewPeekLock = settingsBuilder.AutomaticPeekLockRenewalEnabled;
 
                     transport.PartitioningEnabled = settingsBuilder.PartitioningEnabled;
-
+                    transport.DoNotCreateQueuesEnabled = settingsBuilder.DoNotCreateQueuesEnabled;
                     return transport;
                 });
 
@@ -107,7 +107,7 @@ namespace Rebus.Config
                     transport.AutomaticallyRenewPeekLock = settingsBuilder.AutomaticPeekLockRenewalEnabled;
 
                     transport.PartitioningEnabled = settingsBuilder.PartitioningEnabled;
-
+                    transport.DoNotCreateQueuesEnabled = settingsBuilder.DoNotCreateQueuesEnabled;
                     return transport;
                 });
 

--- a/Rebus.AzureServiceBus/Config/AzureServiceBusTransportSettings.cs
+++ b/Rebus.AzureServiceBus/Config/AzureServiceBusTransportSettings.cs
@@ -10,7 +10,7 @@ namespace Rebus.Config
         internal bool PrefetchingEnabled { get; set; }
         internal int NumberOfMessagesToPrefetch { get; set; }
         internal bool PartitioningEnabled { get; set; }
-
+        internal bool DoNotCreateQueuesEnabled { get; set; }
         /// <summary>
         /// Enables partitioning whereby Azure Service Bus will be able to distribute messages between message stores
         /// and this way increase throughput. Enabling partitioning only has an effect on newly created queues.
@@ -52,6 +52,12 @@ namespace Rebus.Config
         {
             AutomaticPeekLockRenewalEnabled = true;
 
+            return this;
+        }
+
+        public AzureServiceBusTransportSettings DoNotCreateQueues()
+        {
+            DoNotCreateQueuesEnabled = true;
             return this;
         }
     }


### PR DESCRIPTION
This makes it possible to use rebus as "receiveonly" when using a shared
access policy with "listen" permissions

Ref:
#415 

(there will still be an issue with the errorqueue if the bus is configured to use a shared access policy defined only for the input queue)