### PR TITLE
Fix #480

### DIFF
--- a/Rebus.AzureStorage.Tests/Transport/AzureStorageQueuesTransportBasicSendReceive.cs
+++ b/Rebus.AzureStorage.Tests/Transport/AzureStorageQueuesTransportBasicSendReceive.cs
@@ -16,10 +16,12 @@ namespace Rebus.AzureStorage.Tests.Transport
         [Test]
         public async Task GetQueueVisibilityDelayOrNull_NeverReturnsNegativeTimespans()
         {
-            RebusTimeMachine.FakeIt(DateTimeOffset.Parse("2016-06-25T12:20:52.6038001-04:00"));
+            var sendInstant = DateTimeOffset.Now;
+            var deferDate = sendInstant.AddMilliseconds(-350);
+            RebusTimeMachine.FakeIt(sendInstant);
             var result = AzureStorageQueuesTransport.GetQueueVisibilityDelayOrNull(new Dictionary<string, string>
             {
-                {Headers.DeferredUntil, "2016-06-25T12:00:00.6038001-04:00"}
+                {Headers.DeferredUntil, deferDate.ToString("O")}
             });
             RebusTimeMachine.Reset();
             Assert.Null(result);
@@ -28,13 +30,15 @@ namespace Rebus.AzureStorage.Tests.Transport
         [Test]
         public async Task GetQueueVisibilityDelayOrNull_StillReturnsPositiveTimespans()
         {
-            RebusTimeMachine.FakeIt(DateTimeOffset.Parse("2016-06-25T12:00:00.6038001-04:00"));
+            var sendInstant = DateTimeOffset.Now;
+            var deferDate = sendInstant.AddMilliseconds(350);
+            RebusTimeMachine.FakeIt(sendInstant);
             var result = AzureStorageQueuesTransport.GetQueueVisibilityDelayOrNull(new Dictionary<string, string>
             {
-                {Headers.DeferredUntil, "2016-06-25T12:20:52.6038001-04:00"}
+                {Headers.DeferredUntil, deferDate.ToString("O")}
             });
             RebusTimeMachine.Reset();
-            Assert.Greater(result, TimeSpan.Zero);
+            Assert.AreEqual(result, TimeSpan.FromMilliseconds(350));
 
         }
     }

--- a/Rebus.AzureStorage.Tests/Transport/AzureStorageQueuesTransportBasicSendReceive.cs
+++ b/Rebus.AzureStorage.Tests/Transport/AzureStorageQueuesTransportBasicSendReceive.cs
@@ -1,8 +1,41 @@
-﻿using NUnit.Framework;
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Rebus.AzureStorage.Transport;
+using Rebus.Messages;
+using Rebus.Tests;
 using Rebus.Tests.Contracts.Transports;
+using Rebus.Time;
 
 namespace Rebus.AzureStorage.Tests.Transport
 {
     [TestFixture, Category(TestCategory.Azure)]
-    public class AzureStorageQueuesTransportBasicSendReceive : BasicSendReceive<AzureStorageQueuesTransportFactory> { }
+    public class AzureStorageQueuesTransportBasicSendReceive : BasicSendReceive<AzureStorageQueuesTransportFactory>
+    {
+        [Test]
+        public async Task GetQueueVisibilityDelayOrNull_NeverReturnsNegativeTimespans()
+        {
+            RebusTimeMachine.FakeIt(DateTimeOffset.Parse("2016-06-25T12:20:52.6038001-04:00"));
+            var result = AzureStorageQueuesTransport.GetQueueVisibilityDelayOrNull(new Dictionary<string, string>
+            {
+                {Headers.DeferredUntil, "2016-06-25T12:00:00.6038001-04:00"}
+            });
+            RebusTimeMachine.Reset();
+            Assert.Null(result);
+
+        }
+        [Test]
+        public async Task GetQueueVisibilityDelayOrNull_StillReturnsPositiveTimespans()
+        {
+            RebusTimeMachine.FakeIt(DateTimeOffset.Parse("2016-06-25T12:00:00.6038001-04:00"));
+            var result = AzureStorageQueuesTransport.GetQueueVisibilityDelayOrNull(new Dictionary<string, string>
+            {
+                {Headers.DeferredUntil, "2016-06-25T12:20:52.6038001-04:00"}
+            });
+            RebusTimeMachine.Reset();
+            Assert.Greater(result, TimeSpan.Zero);
+
+        }
+    }
 }

--- a/Rebus.AzureStorage/Transport/AzureStorageQueuesTransport.cs
+++ b/Rebus.AzureStorage/Transport/AzureStorageQueuesTransport.cs
@@ -128,7 +128,7 @@ namespace Rebus.AzureStorage.Transport
             return timeToBeReceived;
         }
 
-        static TimeSpan? GetQueueVisibilityDelayOrNull(Dictionary<string, string> headers)
+        public static TimeSpan? GetQueueVisibilityDelayOrNull(Dictionary<string, string> headers)
         {
             string deferredUntilDateTimeOffsetString;
 
@@ -141,7 +141,9 @@ namespace Rebus.AzureStorage.Transport
 
             var enqueueTime = deferredUntilDateTimeOffsetString.ToDateTimeOffset();
 
-            return enqueueTime - RebusTime.Now;
+            var difference = enqueueTime - RebusTime.Now;
+            if (difference <= TimeSpan.Zero) return null;
+            return difference;
         }
 
         static CloudQueueMessage Serialize(string messageId, string popReceipt, Dictionary<string, string> headers, byte[] body)


### PR DESCRIPTION
This addresses issue #480. For short timeouts, the defer window calculation can result in a negative timespan which in-turn blows up the send. This adds bounds checking and returns null if the timespan is less than or equal to zero.
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
