### PR TITLE
Added AutoRegisterHandlersFromThisAssembly and AutoRegisterHandlersFromAssemblyOf<> extension methods to ServiceProvider container adapter to simplify handlers registration

### DIFF
--- a/Rebus.ServiceProvider/Rebus.ServiceProvider.csproj
+++ b/Rebus.ServiceProvider/Rebus.ServiceProvider.csproj
@@ -51,6 +51,7 @@
   <ItemGroup>
     <Compile Include="NetCoreServiceCollectionContainerAdapter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ServiceCollectionExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Rebus\Rebus.csproj">

--- a/Rebus.ServiceProvider/ServiceCollectionExtensions.cs
+++ b/Rebus.ServiceProvider/ServiceCollectionExtensions.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Rebus.Extensions;
+using Rebus.Handlers;
+
+namespace Rebus.ServiceProvider
+{
+    /// <summary>
+    /// Extension methods for making it easy to register Rebus handlers in your <see cref="IServiceCollection"/>
+    /// </summary>
+    public static class ServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Automatically picks up all handler types from the assembly containing <typeparamref name="THandler"/> and registers them in the container
+        /// </summary>
+        /// <typeparam name="THandler">The type of the handler.</typeparam>
+        /// <param name="services">The services.</param>
+        /// <exception cref="System.ArgumentNullException"></exception>
+        public static void AutoRegisterHandlersFromAssemblyOf<THandler>(this IServiceCollection services) where THandler : IHandleMessages
+        {
+            if (services == null)
+                throw new ArgumentNullException(nameof(services));
+
+            var assemblyToRegister = typeof(THandler).Assembly;
+
+            RegisterAssembly(services, assemblyToRegister);
+        }
+
+        /// <summary>
+        /// Automatically picks up all handler types from the calling assembly and registers them in the container
+        /// </summary>
+        /// <param name="services">The services.</param>
+        /// <exception cref="System.ArgumentNullException"></exception>
+        public static void AutoRegisterHandlersFromThisAssembly(this IServiceCollection services)
+        {
+            if (services == null)
+                throw new ArgumentNullException(nameof(services));
+
+            var callingAssembly = Assembly.GetCallingAssembly();
+
+            RegisterAssembly(services, callingAssembly);
+        }
+
+        static IEnumerable<Type> GetImplementedHandlerInterfaces(Type type)
+        {
+            return type.GetInterfaces()
+                .Where(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IHandleMessages<>));
+        }
+
+        static void RegisterAssembly(IServiceCollection services, Assembly assemblyToRegister)
+        {
+            var typesToAutoRegister = assemblyToRegister.GetTypes()
+                .Where(type => !type.IsInterface && !type.IsAbstract)
+                .Select(type => new
+                {
+                    Type = type,
+                    ImplementedHandlerInterfaces = GetImplementedHandlerInterfaces(type).ToList()
+                })
+                .Where(a => a.ImplementedHandlerInterfaces.Any());
+
+            foreach (var type in typesToAutoRegister)
+            {
+                RegisterType(services, type.Type, true);
+            }
+        }
+
+        static void RegisterType(IServiceCollection services, Type typeToRegister, bool auto)
+        {
+            var implementedHandlerInterfaces = GetImplementedHandlerInterfaces(typeToRegister).ToArray();
+
+            if (!implementedHandlerInterfaces.Any())
+                return;
+
+            implementedHandlerInterfaces
+                .ForEach(i => services.AddTransient(i, typeToRegister));
+        }
+    }
+}


### PR DESCRIPTION
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.

…omAssemblyOf<>extension methods to ServiceProvider container adapter