### PR TITLE
Improve `PerformExpiredMessagesCleanupCycle` inside of `SQLServerTran…

### DIFF
--- a/Rebus/Transport/SqlServer/SqlServerTransport.cs
+++ b/Rebus/Transport/SqlServer/SqlServerTransport.cs
@@ -347,12 +347,12 @@ VALUES
                     {
                         command.CommandText =
                             $@"
-DELETE FROM [{_tableName}] 
-    WHERE [id] IN (
-        SELECT TOP 1 [id] FROM [{_tableName}] WITH (ROWLOCK, READPAST)
-            WHERE [recipient] = @recipient 
-                AND [expiration] < getdate()
-    )
+;with TopCTE as (
+	SELECT TOP 1 [id] FROM [{_tableName}] WITH (ROWLOCK, READPAST)
+				WHERE [recipient] = @recipient 
+					AND [expiration] < getdate()
+)
+DELETE FROM TopCTE
 ";
                         command.Parameters.Add("recipient", SqlDbType.NVarChar, RecipientColumnSize).Value = _inputQueueName;
 


### PR DESCRIPTION
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.

…sport ` so that it doesn't select of a non-index column.