### PR TITLE
Removed failing Guid.Empty guard.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ _NCrunch_*
 **/packages/*
 !**/packages/build/
 AssemblyInfo_Patch.cs
+
+# JetBrains Rider
+.idea/

--- a/Rebus.Tests/Testing/TestSagaFixture.cs
+++ b/Rebus.Tests/Testing/TestSagaFixture.cs
@@ -106,6 +106,24 @@ namespace Rebus.Tests.Testing
             
         }
 
+        ///<summary>
+        /// SagaData with non-empty Id is added to SagaFixture.Data.
+        ///</summary>
+        [Test]
+        public void SagaDataWithNonEmptyIdIsAddedToSagaFixtureData()
+        {
+            using (var fixture = SagaFixture.For<MySaga>())
+            {
+                // Arrange
+
+                // Act
+                fixture.Add(new MySagaState { Id = Guid.NewGuid() });
+
+                // Assert
+                Assert.That(fixture.Data.Count(), Is.EqualTo(1));
+            }
+        }
+
         class MySaga : Saga<MySagaState>, IAmInitiatedBy<TestMessage>
         {
             protected override void CorrelateMessages(ICorrelationConfig<MySagaState> config)

--- a/Rebus.Tests/Testing/TestSagaFixture.cs
+++ b/Rebus.Tests/Testing/TestSagaFixture.cs
@@ -5,6 +5,8 @@ using NUnit.Framework;
 using Rebus.Sagas;
 using Rebus.Testing;
 using Rebus.Tests.Contracts;
+using Rebus.Tests.Sagas;
+
 #pragma warning disable 1998
 
 namespace Rebus.Tests.Testing
@@ -121,6 +123,25 @@ namespace Rebus.Tests.Testing
 
                 // Assert
                 Assert.That(fixture.Data.Count(), Is.EqualTo(1));
+            }
+        }
+
+        ///<summary>
+        /// Verify that Id is set upon null Id.
+        ///</summary>
+        [Test]
+        public void IdIsSetUponNullId()
+        {
+            using (var fixture = SagaFixture.For<MySaga>())
+            {
+                // Arrange
+
+                // Act
+                fixture.Add(new MySagaState());
+
+                // Asert
+                Assert.That(fixture.Data.Count(), Is.EqualTo(1));
+                Assert.That(fixture.Data.Single().Id, Is.Not.Null);
             }
         }
 

--- a/Rebus/Testing/SagaFixture.cs
+++ b/Rebus/Testing/SagaFixture.cs
@@ -175,10 +175,7 @@ namespace Rebus.Testing
         /// </summary>
         public void Add(ISagaData sagaDataInstance)
         {
-            if (sagaDataInstance.Id == Guid.Empty)
-            {
-                _inMemorySagaStorage.AddInstance(sagaDataInstance);
-            }
+            _inMemorySagaStorage.AddInstance(sagaDataInstance);
         }
 
         /// <summary>


### PR DESCRIPTION
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
