### PR TITLE
fixed: FastExpressionCompiler usage

### DIFF
--- a/Rebus.Tests/Pipeline/TestCompiledPipelineInvoker.cs
+++ b/Rebus.Tests/Pipeline/TestCompiledPipelineInvoker.cs
@@ -28,6 +28,8 @@ namespace Rebus.Tests.Pipeline
         /// 
         /// 2016/07/18:
         ///     Execution took 23,5 s
+        /// 2017/03/23
+        ///     @dadhi: With FastExpressionCompiler execution took 18 s vs Expression.Compile 38 s
         /// </summary>
         [Test]
         public void CheckTiming()

--- a/Rebus/Pipeline/CompiledPipelineInvoker.cs
+++ b/Rebus/Pipeline/CompiledPipelineInvoker.cs
@@ -45,21 +45,9 @@ namespace Rebus.Pipeline
             where TContext : StepContext
             where TStep : IStep
         {
-            //var expression = GenerateExpression<TContext, TStep>(steps, processMethodName, 0);
-            //return expression.Compile();
-
             var expression = GenerateExpression<TContext, TStep>(steps, processMethodName, 0);
-            var contextParameter = Expression.Parameter(typeof(TContext), "context");
-            var lambdaExpression = Expression.Lambda(expression, contextParameter);
-            return ExpressionCompiler.Compile<Func<TContext, Task>>(lambdaExpression);
-
-            //var expression = GenerateExpression<TContext, TStep>(steps, processMethodName, 0);
-            //var contextParameter = Expression.Parameter(typeof(TContext), "context");
-            //return ExpressionCompiler.TryCompile<Func<TContext, Task>>(
-            //    expression,
-            //    new List<ParameterExpression> {contextParameter},
-            //    new[] {typeof(TContext)}, typeof(Task)
-            //);
+            return ExpressionCompiler.Compile<Func<TContext, Task>>(expression);
+            //return expression.Compile();
         }
 
         /// <summary>


### PR DESCRIPTION
18 vs 38 s on my machine

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
