### PR TITLE
Reworked GetSimpleAssemblyQualifiedName to correctly support generics

### DIFF
--- a/Rebus.Tests/Extensions/TestTypeExtensions.cs
+++ b/Rebus.Tests/Extensions/TestTypeExtensions.cs
@@ -1,0 +1,200 @@
+﻿using System;
+using FluentAssertions;
+using NUnit.Framework;
+using Rebus.Extensions;
+using Rebus.Tests.Contracts;
+
+namespace Rebus.Tests.Extensions
+{
+    [TestFixture]
+    public class TestTypeExtensions : FixtureBase
+    {
+        [Test]
+        public void SimplifiedNameForSimpleMessage()
+        {
+            // arrange
+            var expectedType = typeof(SimpleMessage);
+            var expectedTypeString = "Rebus.Tests.Extensions.SimpleMessage, Rebus.Tests";
+
+            // act
+            var actualTypeStringStatic = typeof(SimpleMessage).GetSimpleAssemblyQualifiedName();
+            var actualTypeStringInstance = new SimpleMessage().GetType().GetSimpleAssemblyQualifiedName();
+                
+            var actualTypeStatic = Type.GetType(actualTypeStringStatic, false);
+            var actualTypeInstance = Type.GetType(actualTypeStringInstance, false);
+
+
+            // assert
+            actualTypeStringStatic.ShouldBeEquivalentTo(expectedTypeString);
+            actualTypeStringInstance.ShouldBeEquivalentTo(expectedTypeString);
+
+            actualTypeStatic.ShouldBeEquivalentTo(expectedType);
+            actualTypeInstance.ShouldBeEquivalentTo(expectedType);
+
+        }
+
+        [Test]
+        public void SimplifiedNameForSimpleNestedMessage()
+        {
+            // arrange
+            var expectedType = typeof(DeclaringClass.SimpleNestedMessage);
+            var expectedTypeString = "Rebus.Tests.Extensions.DeclaringClass+SimpleNestedMessage, Rebus.Tests";
+
+            // act
+            var actualTypeStringStatic = typeof(DeclaringClass.SimpleNestedMessage).GetSimpleAssemblyQualifiedName();
+            var actualTypeStringInstance = new DeclaringClass.SimpleNestedMessage().GetType().GetSimpleAssemblyQualifiedName();
+
+            var actualTypeStatic = Type.GetType(actualTypeStringStatic, false);
+            var actualTypeInstance = Type.GetType(actualTypeStringInstance, false);
+
+
+            // assert
+            actualTypeStringStatic.ShouldBeEquivalentTo(expectedTypeString);
+            actualTypeStringInstance.ShouldBeEquivalentTo(expectedTypeString);
+
+            actualTypeStatic.ShouldBeEquivalentTo(expectedType);
+            actualTypeInstance.ShouldBeEquivalentTo(expectedType);
+        }
+
+        [Test]
+        public void SimplifiedNameForSimpleGenericMessage()
+        {
+            // arrange
+            var expectedType = typeof(SimpleGenericMessage<SimpleMessage>);
+            var expectedTypeString = "Rebus.Tests.Extensions.SimpleGenericMessage`1[[Rebus.Tests.Extensions.SimpleMessage, Rebus.Tests]], Rebus.Tests";
+
+            // act
+            var actualTypeStringStatic = typeof(SimpleGenericMessage<SimpleMessage>).GetSimpleAssemblyQualifiedName();
+            var actualTypeStringInstance = new SimpleGenericMessage<SimpleMessage>().GetType().GetSimpleAssemblyQualifiedName();
+            var actualTypeStringInstanceRuntimeConstructed = typeof(SimpleGenericMessage<>).MakeGenericType(typeof(SimpleMessage)).GetSimpleAssemblyQualifiedName();
+
+            var actualTypeStatic = Type.GetType(actualTypeStringStatic, false);
+            var actualTypeInstance = Type.GetType(actualTypeStringInstance, false);
+            var actualTypeInstanceRuntimeConstructed = Type.GetType(actualTypeStringInstanceRuntimeConstructed, false);
+                
+            // assert   
+            actualTypeStringStatic.ShouldBeEquivalentTo(expectedTypeString);
+            actualTypeStringInstance.ShouldBeEquivalentTo(expectedTypeString);
+            actualTypeStringInstanceRuntimeConstructed.ShouldBeEquivalentTo(expectedTypeString);
+
+            actualTypeStatic.ShouldBeEquivalentTo(expectedType);
+            actualTypeInstance.ShouldBeEquivalentTo(expectedType);
+            actualTypeInstanceRuntimeConstructed.ShouldBeEquivalentTo(expectedType);
+
+        }
+
+        [Test]
+        public void SimplifiedNameForSimpleGenericNestedMessage()
+        {
+            // arrange
+            var expectedType = typeof(DeclaringClass.SimpleNestedGenericMessage<SimpleMessage>);
+            var expectedTypeString = "Rebus.Tests.Extensions.DeclaringClass+SimpleNestedGenericMessage`1[[Rebus.Tests.Extensions.SimpleMessage, Rebus.Tests]], Rebus.Tests";
+
+            // act
+            var actualTypeStringStatic = typeof(DeclaringClass.SimpleNestedGenericMessage<SimpleMessage>).GetSimpleAssemblyQualifiedName();
+            var actualTypeStringInstance = new DeclaringClass.SimpleNestedGenericMessage<SimpleMessage>().GetType().GetSimpleAssemblyQualifiedName();
+            var actualTypeStringInstanceRuntimeConstructed = typeof(DeclaringClass.SimpleNestedGenericMessage<>).MakeGenericType(typeof(SimpleMessage)).GetSimpleAssemblyQualifiedName();
+
+            var actualTypeStatic = Type.GetType(actualTypeStringStatic, false);
+            var actualTypeInstance = Type.GetType(actualTypeStringInstance, false);
+            var actualTypeInstanceRuntimeConstructed = Type.GetType(actualTypeStringInstanceRuntimeConstructed, false);
+
+            // assert   
+            actualTypeStringStatic.ShouldBeEquivalentTo(expectedTypeString);
+            actualTypeStringInstance.ShouldBeEquivalentTo(expectedTypeString);
+            actualTypeStringInstanceRuntimeConstructed.ShouldBeEquivalentTo(expectedTypeString);
+
+            actualTypeStatic.ShouldBeEquivalentTo(expectedType);
+            actualTypeInstance.ShouldBeEquivalentTo(expectedType);
+            actualTypeInstanceRuntimeConstructed.ShouldBeEquivalentTo(expectedType);
+        }
+
+        [Test]
+        public void SimplifiedNameForComplexGenericMessage()
+        {
+            // arrange
+            var expectedType = typeof(ComplexGenericMessage<SimpleMessage, int>);
+            var expectedTypeString = "Rebus.Tests.Extensions.ComplexGenericMessage`2[[Rebus.Tests.Extensions.SimpleMessage, Rebus.Tests],[System.Int32, mscorlib]], Rebus.Tests";
+
+            // act
+            var actualTypeStringStatic = typeof(ComplexGenericMessage<SimpleMessage, int>).GetSimpleAssemblyQualifiedName();
+            var actualTypeStringInstance = new ComplexGenericMessage<SimpleMessage, int>().GetType().GetSimpleAssemblyQualifiedName();
+            var actualTypeStringInstanceRuntimeConstructed = typeof(ComplexGenericMessage<,>).MakeGenericType(typeof(SimpleMessage), typeof(int)).GetSimpleAssemblyQualifiedName();
+
+            var actualTypeStatic = Type.GetType(actualTypeStringStatic, false);
+            var actualTypeInstance = Type.GetType(actualTypeStringInstance, false);
+            var actualTypeInstanceRuntimeConstructed = Type.GetType(actualTypeStringInstanceRuntimeConstructed, false);
+
+            // assert   
+            actualTypeStringStatic.ShouldBeEquivalentTo(expectedTypeString);
+            actualTypeStringInstance.ShouldBeEquivalentTo(expectedTypeString);
+            actualTypeStringInstanceRuntimeConstructed.ShouldBeEquivalentTo(expectedTypeString);
+
+            actualTypeStatic.ShouldBeEquivalentTo(expectedType);
+            actualTypeInstance.ShouldBeEquivalentTo(expectedType);
+            actualTypeInstanceRuntimeConstructed.ShouldBeEquivalentTo(expectedType);
+
+        }
+
+        [Test]
+        public void SimplifiedNameForComplexGenericNestedMessage()
+        {
+            // arrange
+            var expectedType = typeof(DeclaringClass.ComplexNestedGenericMessage<SimpleMessage, int>);
+            var expectedTypeString = "Rebus.Tests.Extensions.DeclaringClass+ComplexNestedGenericMessage`2[[Rebus.Tests.Extensions.SimpleMessage, Rebus.Tests],[System.Int32, mscorlib]], Rebus.Tests";
+
+            // act
+            var actualTypeStringStatic = typeof(DeclaringClass.ComplexNestedGenericMessage<SimpleMessage, int>).GetSimpleAssemblyQualifiedName();
+            var actualTypeStringInstance = new DeclaringClass.ComplexNestedGenericMessage<SimpleMessage, int>().GetType().GetSimpleAssemblyQualifiedName();
+            var actualTypeStringInstanceRuntimeConstructed = typeof(DeclaringClass.ComplexNestedGenericMessage<,>).MakeGenericType(typeof(SimpleMessage), typeof(int)).GetSimpleAssemblyQualifiedName();
+
+            var actualTypeStatic = Type.GetType(actualTypeStringStatic, false);
+            var actualTypeInstance = Type.GetType(actualTypeStringInstance, false);
+            var actualTypeInstanceRuntimeConstructed = Type.GetType(actualTypeStringInstanceRuntimeConstructed, false);
+
+            // assert   
+            actualTypeStringStatic.ShouldBeEquivalentTo(expectedTypeString);
+            actualTypeStringInstance.ShouldBeEquivalentTo(expectedTypeString);
+            actualTypeStringInstanceRuntimeConstructed.ShouldBeEquivalentTo(expectedTypeString);
+
+            actualTypeStatic.ShouldBeEquivalentTo(expectedType);
+            actualTypeInstance.ShouldBeEquivalentTo(expectedType);
+            actualTypeInstanceRuntimeConstructed.ShouldBeEquivalentTo(expectedType);
+        }
+    }
+
+
+    public class SimpleGenericMessage<T1>
+    {   
+        public string Something { get; set; }
+    }
+
+    public class ComplexGenericMessage<T1, T2>
+    {
+        public string Something { get; set; }
+    }
+
+    public class SimpleMessage
+    {
+        public string Something { get; set; }
+
+    }
+
+    public class DeclaringClass
+    {
+        public class SimpleNestedMessage
+        {
+            public string SomethingElse { get; set; }
+        }
+
+        public class SimpleNestedGenericMessage<T1>
+        {
+            public string Something { get; set; }
+        }
+
+        public class ComplexNestedGenericMessage<T1, T2>
+        {   
+            public string Something { get; set; }
+        }
+    }
+}   

--- a/Rebus.Tests/Rebus.Tests.csproj
+++ b/Rebus.Tests/Rebus.Tests.csproj
@@ -92,6 +92,7 @@
     <Compile Include="Encryption\TestCustomEncryption.cs" />
     <Compile Include="Encryption\TestDisableEncryption.cs" />
     <Compile Include="Events\TestBusLifetimeEvents.cs" />
+    <Compile Include="Extensions\TestTypeExtensions.cs" />
     <Compile Include="Integration\TestUnserializableException.cs" />
     <Compile Include="Persistence\Filesystem\FilesystemBasicStoreAndRetrieveOperations.cs" />
     <Compile Include="Persistence\InMem\TestSagaCorrelationInMem.cs" />

--- a/Rebus/Extensions/TypeExtensions.cs
+++ b/Rebus/Extensions/TypeExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text;
 
 namespace Rebus.Extensions
 {
@@ -31,7 +32,37 @@ namespace Rebus.Extensions
         /// </summary>
         public static string GetSimpleAssemblyQualifiedName(this Type type)
         {
-            return $"{type.FullName}, {type.Assembly.GetName().Name}";
+            return BuildSimpleAssemblyQualifiedName(type, new StringBuilder()).ToString();
+        }
+
+        private static StringBuilder BuildSimpleAssemblyQualifiedName(Type type, StringBuilder sb)
+        {
+            if (!type.IsGenericType)
+            {
+                sb.Append($"{type.FullName}, {type.Assembly.GetName().Name}");
+                return sb;
+            }
+
+            if (type.DeclaringType != null)
+                if (!type.DeclaringType.IsGenericType)
+                    sb.Append($"{type.DeclaringType.FullName}+");
+                else
+                    throw new NotSupportedException("Generic declaring types are not supported");
+            else
+                sb.Append($"{type.Namespace}.");
+
+            sb.Append($"{type.Name}[");
+            var arguments = type.GetGenericArguments();
+            for (var i = 0; i < arguments.Length; i++)
+            {
+                sb.Append(i == 0 ? "[" : ",[");
+                BuildSimpleAssemblyQualifiedName(arguments[i], sb);
+                sb.Append("]");
+            }
+
+            sb.Append($"], {type.Assembly.GetName().Name}");
+
+            return sb;
         }
     }
 }


### PR DESCRIPTION
I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase.