### PR TITLE
Bumping TFM down to "netstandard1.3"

### DIFF
--- a/Rebus.Tests.Contracts/Extensions/Ponder.cs
+++ b/Rebus.Tests.Contracts/Extensions/Ponder.cs
@@ -17,7 +17,7 @@ namespace Rebus.Tests.Contracts.Extensions
 
             foreach(var dot in dots)
             {
-                var propertyInfo = obj.GetType().GetTypeInfo().GetProperty(dot);
+                var propertyInfo = obj.GetType().GetProperty(dot);
                 if (propertyInfo == null) return null;
                 obj = propertyInfo.GetValue(obj, new object[0]);
                 if (obj == null) break;

--- a/Rebus.Tests.Contracts/Rebus.Tests.Contracts.csproj
+++ b/Rebus.Tests.Contracts/Rebus.Tests.Contracts.csproj
@@ -5,7 +5,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Rebus.Tests.Contracts</RootNamespace>
     <AssemblyName>Rebus.Tests.Contracts</AssemblyName>
-    <TargetFrameworks>net45;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Authors>mookid8000</Authors>
     <PackageVersion>4.0.0-b01</PackageVersion>
@@ -39,8 +39,8 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <DefineConstants>NET45</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
-    <DefineConstants>NETSTANDARD1_6</DefineConstants>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+    <DefineConstants>NETSTANDARD1_3</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net45|AnyCPU'">
     <TreatSpecificWarningsAsErrors />
@@ -49,7 +49,7 @@
     <Compile Remove="Properties\AssemblyInfo.cs" />
     <None Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="System.Threading" Version="4.3.0" />
     <PackageReference Include="System.Threading.ThreadPool" Version="4.3.0" />
   </ItemGroup>
@@ -59,7 +59,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="FluentAssertions" Version="4.19.2" />
-    <PackageReference Include="NUnit" Version="3.6.1" />
+    <PackageReference Include="NUnit" Version="3.7.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="Microsoft.CSharp" />

--- a/Rebus.Tests.Contracts/Sagas/TestCorrelationProperty.cs
+++ b/Rebus.Tests.Contracts/Sagas/TestCorrelationProperty.cs
@@ -28,7 +28,7 @@ namespace Rebus.Tests.Contracts.Sagas
 
         void Validate()
         {
-            var propertyType = SagaDataType.GetTypeInfo().GetProperty(PropertyName).PropertyType;
+            var propertyType = SagaDataType.GetProperty(PropertyName).PropertyType;
 
             if (AllowedCorrelationPropertyTypes.Contains(propertyType)) return;
 

--- a/Rebus.Tests.Contracts/TestConfig.cs
+++ b/Rebus.Tests.Contracts/TestConfig.cs
@@ -13,7 +13,7 @@ namespace Rebus.Tests.Contracts
         {
 #if NET45
         return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "test");
-#elif NETSTANDARD1_6
+#elif NETSTANDARD1_3
         return Path.Combine(AppContext.BaseDirectory, "test");
 #endif
 

--- a/Rebus.Tests/Encryption/TestEncryptor.cs
+++ b/Rebus.Tests/Encryption/TestEncryptor.cs
@@ -15,7 +15,7 @@ namespace Rebus.Tests.Encryption
             {
 #if NET45
                 new RijndaelEncryptor("not a valid key");
-#elif NETSTANDARD1_6
+#elif NETSTANDARD1_3
                 new AesEncryptor("not a valid key");
 #endif
 

--- a/Rebus.Tests/Extensions/Ponder.cs
+++ b/Rebus.Tests/Extensions/Ponder.cs
@@ -17,7 +17,7 @@ namespace Rebus.Tests.Extensions
 
             foreach(var dot in dots)
             {
-                var propertyInfo = obj.GetType().GetTypeInfo().GetProperty(dot);
+                var propertyInfo = obj.GetType().GetProperty(dot);
                 if (propertyInfo == null) return null;
                 obj = propertyInfo.GetValue(obj, new object[0]);
                 if (obj == null) break;

--- a/Rebus.Tests/Integration/TestRetry.cs
+++ b/Rebus.Tests/Integration/TestRetry.cs
@@ -22,7 +22,7 @@ namespace Rebus.Tests.Integration
     [TestFixture]
     public class TestRetry : FixtureBase
     {
-        static readonly string InputQueueName = TestConfig.GetName($"test.rebus2.retries.input@{Environment.MachineName}");
+        static readonly string InputQueueName = TestConfig.GetName($"test.rebus2.retries.input@{GetMachineName()}");
         static readonly string ErrorQueueName = TestConfig.GetName("rebus2.error");
 
         BuiltinHandlerActivator _handlerActivator;
@@ -91,6 +91,15 @@ namespace Rebus.Tests.Integration
             var expectedNumberOfAttemptedDeliveries = numberOfRetries;
 
             Assert.That(attemptedDeliveries, Is.EqualTo(expectedNumberOfAttemptedDeliveries));
+        }
+
+        private static string GetMachineName()
+        {
+#if NETSTANDARD1_3
+            return Environment.GetEnvironmentVariable("COMPUTERNAME") ?? Environment.GetEnvironmentVariable("HOSTNAME");
+#else
+            return Environment.MachineName;
+#endif
         }
     }
 }

--- a/Rebus.Tests/Pipeline/TestPipelineInvocation.cs
+++ b/Rebus.Tests/Pipeline/TestPipelineInvocation.cs
@@ -55,6 +55,12 @@ namespace Rebus.Tests.Pipeline
         [TestCase(ThingToCheck.NewPipelineInvoker)]
         public async Task ComparePerf(ThingToCheck whatToCheck)
         {
+#if NETSTANDARD1_3
+            await Task.CompletedTask;
+#else
+            await Task.FromResult(false);
+#endif
+
             var iterations = 100000;
             var pipeline = CreateFakePipeline(10).ToArray();
             var invoker = GetInvoker(whatToCheck, pipeline);

--- a/Rebus.Tests/Rebus.Tests.csproj
+++ b/Rebus.Tests/Rebus.Tests.csproj
@@ -5,7 +5,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Rebus.Tests</RootNamespace>
     <AssemblyName>Rebus.Tests</AssemblyName>
-    <TargetFrameworks>net45;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Authors>mookid8000</Authors>
     <PackageLicenseUrl>https://raw.githubusercontent.com/rebus-org/Rebus/master/LICENSE.md</PackageLicenseUrl>
@@ -34,10 +34,10 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <DefineConstants>NET45</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
-    <DefineConstants>NETSTANDARD1_6</DefineConstants>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+    <DefineConstants>NETSTANDARD1_3</DefineConstants>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="System.Threading" Version="4.3.0" />
     <PackageReference Include="System.Threading.ThreadPool" Version="4.3.0" />
   </ItemGroup>
@@ -48,7 +48,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="FluentAssertions" Version="4.19.2" />
-    <PackageReference Include="NUnit" Version="3.6.1" />
+    <PackageReference Include="NUnit" Version="3.7.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System" />

--- a/Rebus.Tests/Sagas/TestHeaderCorrelation.cs
+++ b/Rebus.Tests/Sagas/TestHeaderCorrelation.cs
@@ -103,6 +103,12 @@ namespace Rebus.Tests.Sagas
 
             public async Task Handle(MyMessage message)
             {
+#if NETSTANDARD1_3
+                await Task.CompletedTask;
+#else
+                await Task.FromResult(false);
+#endif
+
                 _sagaDataCounters.AddOrUpdate(Data.Id, 1, (_, count) => count + 1);
                 _sharedCounter.Decrement();
             }

--- a/Rebus.Tests/Sagas/TestSagaCorrelationPropertyNesting.cs
+++ b/Rebus.Tests/Sagas/TestSagaCorrelationPropertyNesting.cs
@@ -61,6 +61,12 @@ namespace Rebus.Tests.Sagas
 
             public async Task Handle(MyMsg message)
             {
+#if NETSTANDARD1_3
+                await Task.CompletedTask;
+#else
+                await Task.FromResult(false);
+#endif
+
                 if (Data.Child == null)
                 {
                     Data.Child = new Child { Property = message.CorrId };

--- a/Rebus/Auditing/Messages/AuditingHelper.cs
+++ b/Rebus/Auditing/Messages/AuditingHelper.cs
@@ -37,7 +37,16 @@ namespace Rebus.Auditing.Messages
             }
 
             headers[AuditHeaders.AuditTime] = RebusTime.Now.ToString("O");
-            headers[AuditHeaders.MachineName] = Environment.MachineName;
+            headers[AuditHeaders.MachineName] = GetMachineName();
+        }
+
+        private static string GetMachineName()
+        {
+#if NETSTANDARD1_3
+            return Environment.GetEnvironmentVariable("COMPUTERNAME") ?? Environment.GetEnvironmentVariable("HOSTNAME");
+#else
+            return Environment.MachineName;
+#endif
         }
     }
 }

--- a/Rebus/Auditing/Sagas/SaveSagaDataSnapshotStep.cs
+++ b/Rebus/Auditing/Sagas/SaveSagaDataSnapshotStep.cs
@@ -34,7 +34,7 @@ namespace Rebus.Auditing.Sagas
                 .Where(i => i.HasSaga)
                 .Select(i => new
                 {
-                    Handler = i.Handler,
+                    i.Handler,
                     SagaData = i.GetSagaData()
                 })
                 .Where(a => a.SagaData != null)
@@ -60,8 +60,17 @@ namespace Rebus.Auditing.Sagas
                 {SagaAuditingMetadataKeys.SagaHandlerType, handler.GetType().GetSimpleAssemblyQualifiedName()},
                 {SagaAuditingMetadataKeys.MessageType, message.GetMessageType()},
                 {SagaAuditingMetadataKeys.MessageId, message.GetMessageId()},
-                {SagaAuditingMetadataKeys.MachineName, Environment.MachineName},
+                {SagaAuditingMetadataKeys.MachineName, GetMachineName()}
             };
+        }
+
+        private static string GetMachineName()
+        {
+#if NETSTANDARD1_3
+            return Environment.GetEnvironmentVariable("COMPUTERNAME") ?? Environment.GetEnvironmentVariable("HOSTNAME");
+#else
+            return Environment.MachineName;
+#endif
         }
     }
 }

--- a/Rebus/Encryption/AesEncryptor.cs
+++ b/Rebus/Encryption/AesEncryptor.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD1_6
+﻿#if NETSTANDARD1_3
 using System;
 using System.IO;
 using System.Security.Cryptography;

--- a/Rebus/Encryption/EncryptionConfigurationExtensions.cs
+++ b/Rebus/Encryption/EncryptionConfigurationExtensions.cs
@@ -19,7 +19,7 @@ namespace Rebus.Encryption
         {
 #if NET45
             EnableCustomEncryption(configurer).Register(c => new RijndaelEncryptor(key));
-#elif NETSTANDARD1_6
+#elif NETSTANDARD1_3
             EnableCustomEncryption(configurer).Register(c => new AesEncryptor(key));
 #endif
         }

--- a/Rebus/Exceptions/ConcurrencyException.cs
+++ b/Rebus/Exceptions/ConcurrencyException.cs
@@ -11,7 +11,7 @@ namespace Rebus.Exceptions
 #if NET45
     [Serializable]
     public class ConcurrencyException : Exception
-# elif NETSTANDARD1_6
+# elif NETSTANDARD1_3
     public class ConcurrencyException : Exception
 #endif
     {

--- a/Rebus/Exceptions/RebusApplicationException.cs
+++ b/Rebus/Exceptions/RebusApplicationException.cs
@@ -11,7 +11,7 @@ namespace Rebus.Exceptions
 #if NET45
     [Serializable]
     public class RebusApplicationException : Exception
-# elif NETSTANDARD1_6
+# elif NETSTANDARD1_3
     public class RebusApplicationException : Exception
 #endif
     {

--- a/Rebus/Exceptions/RebusConfigurationException.cs
+++ b/Rebus/Exceptions/RebusConfigurationException.cs
@@ -11,7 +11,7 @@ namespace Rebus.Exceptions
 #if NET45
     [Serializable]
     public class RebusConfigurationException : ApplicationException
-# elif NETSTANDARD1_6
+# elif NETSTANDARD1_3
     public class RebusConfigurationException : Exception
 #endif
     {

--- a/Rebus/Extensions/TypeExtensions.cs
+++ b/Rebus/Extensions/TypeExtensions.cs
@@ -15,7 +15,7 @@ namespace Rebus.Extensions
         /// </summary>
         public static IEnumerable<Type> GetBaseTypes(this Type type)
         {
-            foreach (var implementedInterface in type.GetTypeInfo().GetInterfaces())
+            foreach (var implementedInterface in type.GetInterfaces())
             {
                 yield return implementedInterface;
             }
@@ -39,7 +39,7 @@ namespace Rebus.Extensions
 
         static StringBuilder BuildSimpleAssemblyQualifiedName(Type type, StringBuilder sb)
         {
-#if NETSTANDARD1_6
+#if NETSTANDARD1_3
             var typeInfo = type.GetTypeInfo();
             if (!typeInfo.IsGenericType)
             {
@@ -57,7 +57,7 @@ namespace Rebus.Extensions
             var name = fullName.Substring(0, requiredPosition);
             sb.Append($"{name}[");
 
-            var arguments = typeInfo.GetGenericArguments();
+            var arguments = type.GetGenericArguments();
             for (var i = 0; i < arguments.Length; i++)
             {
                 sb.Append(i == 0 ? "[" : ", [");

--- a/Rebus/Persistence/FileSystem/FileSystemSagaSnapshotStorage.cs
+++ b/Rebus/Persistence/FileSystem/FileSystemSagaSnapshotStorage.cs
@@ -54,7 +54,7 @@ namespace Rebus.Persistence.FileSystem
 #if NET45
                 var message =
                     $"Could not write dummy file to saga snapshot directory '{_snapshotDirectory}' - is it writable for the {Environment.UserDomainName} / {Environment.UserName} account?";
-#elif NETSTANDARD1_6
+#elif NETSTANDARD1_3
                 var message =
                     $"Could not write dummy file to saga snapshot directory '{_snapshotDirectory}' - is it writable for the current user account?";
 #endif

--- a/Rebus/Persistence/FileSystem/FilesystemSagaIndex.cs
+++ b/Rebus/Persistence/FileSystem/FilesystemSagaIndex.cs
@@ -118,7 +118,7 @@ namespace Rebus.Persistence.FileSystem
 
             foreach (var dot in dots)
             {
-                var propertyInfo = obj.GetType().GetTypeInfo().GetProperty(dot);
+                var propertyInfo = obj.GetType().GetProperty(dot);
                 if (propertyInfo == null) return null;
                 obj = propertyInfo.GetValue(obj, new object[0]);
                 if (obj == null) break;

--- a/Rebus/Persistence/FileSystem/FilesystemSagaStorage.cs
+++ b/Rebus/Persistence/FileSystem/FilesystemSagaStorage.cs
@@ -44,7 +44,7 @@ namespace Rebus.Persistence.FileSystem
                 {
                     var sagaData = index.FindById((Guid) propertyValue);
 
-                    if (!sagaDataType.GetTypeInfo().IsInstanceOfType(sagaData))
+                    if (!sagaDataType.IsInstanceOfType(sagaData))
                     {
                         return null;
                     }

--- a/Rebus/Persistence/InMem/InMemorySubscriberStore.cs
+++ b/Rebus/Persistence/InMem/InMemorySubscriberStore.cs
@@ -11,7 +11,7 @@ namespace Rebus.Persistence.InMem
     {
 #if NET45
         static readonly StringComparer StringComparer = StringComparer.InvariantCultureIgnoreCase;
-#elif NETSTANDARD1_6
+#elif NETSTANDARD1_3
         static readonly StringComparer StringComparer = StringComparer.OrdinalIgnoreCase;
 #endif
 

--- a/Rebus/Pipeline/Invokers/CompiledPipelineInvoker.cs
+++ b/Rebus/Pipeline/Invokers/CompiledPipelineInvoker.cs
@@ -86,8 +86,8 @@ namespace Rebus.Pipeline.Invokers
 
         static MethodInfo GetProcessMethod(IStep step, string methodName, Type contextType)
         {
-#if NETSTANDARD1_6
-            var processMethod = step.GetType().GetTypeInfo().GetMethod(methodName, new[] { contextType, typeof(Func<Task>) });
+#if NETSTANDARD1_3
+            var processMethod = step.GetType().GetMethod(methodName, new[] { contextType, typeof(Func<Task>) });
 #else
             var processMethod = step.GetType().GetMethod(methodName, new[] { contextType, typeof(Func<Task>) });
 #endif

--- a/Rebus/Pipeline/Receive/ActivateHandlersStep.cs
+++ b/Rebus/Pipeline/Receive/ActivateHandlersStep.cs
@@ -63,7 +63,6 @@ namespace Rebus.Pipeline.Receive
         MethodInfo GetDispatchMethod(Type messageType)
         {
             return GetType()
-                .GetTypeInfo()
                 .GetMethod(nameof(GetHandlerInvokers), BindingFlags.NonPublic | BindingFlags.Instance)
                 .MakeGenericMethod(messageType);
         }

--- a/Rebus/Pipeline/Receive/HandlerInvoker.cs
+++ b/Rebus/Pipeline/Receive/HandlerInvoker.cs
@@ -27,7 +27,7 @@ namespace Rebus.Pipeline.Receive
             return CanBeInitiatedByCache
                 .GetOrAdd($"{Handler.GetType().FullName}::{messageType.FullName}", _ =>
                 {
-                    var implementedInterfaces = Saga.GetType().GetTypeInfo().GetInterfaces();
+                    var implementedInterfaces = Saga.GetType().GetInterfaces();
 
                     var handlerTypesToLookFor = new[] { messageType }.Concat(messageType.GetBaseTypes())
                         .Select(baseType => typeof(IAmInitiatedBy<>).MakeGenericType(baseType));
@@ -167,7 +167,7 @@ namespace Rebus.Pipeline.Receive
                 throw new InvalidOperationException($"Attempted to set {sagaData} as saga data on handler {_handler}, but the handler is not a saga!");
             }
 
-            var dataProperty = _handler.GetType().GetTypeInfo().GetProperty(SagaDataPropertyName);
+            var dataProperty = _handler.GetType().GetProperty(SagaDataPropertyName);
 
             if (dataProperty == null)
             {

--- a/Rebus/Rebus.csproj
+++ b/Rebus/Rebus.csproj
@@ -5,7 +5,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Rebus</RootNamespace>
     <AssemblyName>Rebus</AssemblyName>
-    <TargetFrameworks>net45;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Authors>mookid8000</Authors>
     <PackageVersion>4.0.0-b01</PackageVersion>
@@ -41,20 +41,25 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <DefineConstants>NET45</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
-    <DefineConstants>NETSTANDARD1_6</DefineConstants>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+    <DefineConstants>NETSTANDARD1_3</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Properties\AssemblyInfo.cs" />
     <None Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="System.Threading" Version="4.3.0" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit.LightWeight" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit.ILGeneration" Version="4.3.0" />
+    <PackageReference Include="System.Reflection" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Extensions" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />

--- a/Rebus/Reflection/Ponder.cs
+++ b/Rebus/Reflection/Ponder.cs
@@ -17,7 +17,7 @@ namespace Rebus.Reflection
 
             foreach(var dot in dots)
             {
-                var propertyInfo = obj.GetType().GetTypeInfo().GetProperty(dot);
+                var propertyInfo = obj.GetType().GetProperty(dot);
                 if (propertyInfo == null) return null;
                 obj = propertyInfo.GetValue(obj, new object[0]);
                 if (obj == null) break;

--- a/Rebus/Retry/Simple/FailedMessageWrapperStep.cs
+++ b/Rebus/Retry/Simple/FailedMessageWrapperStep.cs
@@ -59,7 +59,7 @@ which is then detected by this wrapper step.")]
                     {
                         const BindingFlags bindingFlags = BindingFlags.Instance | BindingFlags.NonPublic;
 
-                        var genericWrapMethod = GetType().GetTypeInfo().GetMethod(nameof(Wrap), bindingFlags);
+                        var genericWrapMethod = GetType().GetMethod(nameof(Wrap), bindingFlags);
 
                         return genericWrapMethod.MakeGenericMethod(type);
                     })

--- a/Rebus/Retry/Simple/VerifyCannotSendFailedMessageWrapperStep.cs
+++ b/Rebus/Retry/Simple/VerifyCannotSendFailedMessageWrapperStep.cs
@@ -18,7 +18,7 @@ namespace Rebus.Retry.Simple
 
             if (body != null)
             {
-                var interfaces = body.GetType().GetTypeInfo().GetInterfaces();
+                var interfaces = body.GetType().GetInterfaces();
 
                 if (interfaces.Any(i => i.GetTypeInfo().IsGenericType && i.GetGenericTypeDefinition() == typeof(IFailed<>)))
                 {

--- a/Rebus/Routing/Exceptions/AutoForwardOnExceptionConfigurationExtensions.cs
+++ b/Rebus/Routing/Exceptions/AutoForwardOnExceptionConfigurationExtensions.cs
@@ -77,7 +77,7 @@ namespace Rebus.Routing.Exceptions
                 }
                 catch (Exception exception)
                 {
-                    if (!_exceptionType.GetTypeInfo().IsInstanceOfType(exception))
+                    if (!_exceptionType.IsInstanceOfType(exception))
                     {
                         throw;
                     }

--- a/Rebus/Sagas/CorrelationProperty.cs
+++ b/Rebus/Sagas/CorrelationProperty.cs
@@ -79,7 +79,7 @@ namespace Rebus.Sagas
 
             foreach (var name in path)
             {
-                propertyInfo = type.GetTypeInfo().GetProperty(name);
+                propertyInfo = type.GetProperty(name);
 
                 if (propertyInfo == null) return null;
 

--- a/Rebus/Sagas/LoadSagaDataStep.cs
+++ b/Rebus/Sagas/LoadSagaDataStep.cs
@@ -169,7 +169,7 @@ Afterwards, all the created/loaded saga data is updated appropriately.")]
             {
                 if (IgnoredProperties.Contains(correlationProperty.PropertyName)) return;
 
-                var correlationPropertyInfo = newSagaData.GetType().GetTypeInfo().GetProperty(correlationProperty.PropertyName);
+                var correlationPropertyInfo = newSagaData.GetType().GetProperty(correlationProperty.PropertyName);
 
                 if (correlationPropertyInfo == null) return;
 

--- a/Rebus/Sagas/Saga.cs
+++ b/Rebus/Sagas/Saga.cs
@@ -28,7 +28,7 @@ namespace Rebus.Sagas
             return CachedUserHasOverriddenConflictResolutionMethod
                 .GetOrAdd(GetType(), type =>
                 {
-                    var typeDeclaringTheConflictResolutionMethod = GetType().GetTypeInfo()
+                    var typeDeclaringTheConflictResolutionMethod = GetType()
                         .GetMethod("ResolveConflict", BindingFlags.Instance | BindingFlags.NonPublic).DeclaringType;
 
                     if (typeDeclaringTheConflictResolutionMethod == null)

--- a/Rebus/Serialization/Json/JsonSerializer.cs
+++ b/Rebus/Serialization/Json/JsonSerializer.cs
@@ -68,7 +68,7 @@ namespace Rebus.Serialization.Json
             var headers = message.Headers.Clone();
 #if NET45
             headers[Headers.ContentType] = $"{JsonContentType};charset={_encoding.HeaderName}";
-#elif NETSTANDARD1_6
+#elif NETSTANDARD1_3
             headers[Headers.ContentType] = $"{JsonContentType};charset={_encoding.WebName}";
 #endif
             return new TransportMessage(headers, bytes);

--- a/Rebus/Testing/FakeBusEventFactory.cs
+++ b/Rebus/Testing/FakeBusEventFactory.cs
@@ -36,9 +36,15 @@ namespace Rebus.Testing
 
         static ConstructorInfo GetConstructor(Type eventType)
         {
+#if NETSTANDARD1_3
+            // TODO: BindingFlags.CreateInstance is not available on .NET Standard 1.0-1.4
+            // Should we care about it? Will it hurt us?
+            const BindingFlags flags = BindingFlags.NonPublic | BindingFlags.Instance;
+#else
             const BindingFlags flags = BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.CreateInstance;
+#endif
 
-            var constructor = eventType.GetTypeInfo().GetConstructors(flags).FirstOrDefault();
+            var constructor = eventType.GetConstructors(flags).FirstOrDefault();
             if (constructor != null)
             {
                 return constructor;

--- a/Rebus/Testing/FakeBusEventRecorder.cs
+++ b/Rebus/Testing/FakeBusEventRecorder.cs
@@ -48,7 +48,7 @@ namespace Rebus.Testing
             {
                 var compatibleHandlerType = typeof(Action<>).MakeGenericType(fakeBusEvent.GetType());
 
-                if (!compatibleHandlerType.GetTypeInfo().IsInstanceOfType(callback)) continue;
+                if (!compatibleHandlerType.IsInstanceOfType(callback)) continue;
 
                 try
                 {

--- a/Rebus/Threading/SystemThreadingTimer/SystemThreadingTimerAsyncTaskFactory.cs
+++ b/Rebus/Threading/SystemThreadingTimer/SystemThreadingTimerAsyncTaskFactory.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 #if NET45
 using System.Timers;
-#elif NETSTANDARD1_6
+#elif NETSTANDARD1_3
 using System.Threading;
 #endif
 using System.Threading.Tasks;

--- a/Rebus/Threading/SystemTimersTimer/TimerAsyncTask.cs
+++ b/Rebus/Threading/SystemTimersTimer/TimerAsyncTask.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 #if NET45
 using System.Timers;
-#elif NETSTANDARD1_6
+#elif NETSTANDARD1_3
 using System.Threading;
 #endif
 using System.Threading.Tasks;
@@ -68,14 +68,14 @@ namespace Rebus.Threading.SystemTimersTimer
             _timer = new Timer(Interval.TotalMilliseconds);
             _timer.Elapsed += (o, ea) => Tick();
             _timer.Start();
-#elif NETSTANDARD1_6
+#elif NETSTANDARD1_3
             _timer = new Timer(Tick, null, Interval, Interval);
 #endif
         }
 
 #if NET45
         async void Tick()
-#elif NETSTANDARD1_6
+#elif NETSTANDARD1_3
         async void Tick(object state)
 #endif
         {

--- a/Rebus/Threading/SystemTimersTimer/TimerAsyncTaskFactory.cs
+++ b/Rebus/Threading/SystemTimersTimer/TimerAsyncTaskFactory.cs
@@ -2,7 +2,7 @@
 using System.Threading.Tasks;
 #if NET45
 using System.Timers;
-#elif NETSTANDARD1_6
+#elif NETSTANDARD1_3
 using System.Threading;
 #endif
 using Rebus.Logging;

--- a/Rebus/Transport/AmbientTransactionContext.cs
+++ b/Rebus/Transport/AmbientTransactionContext.cs
@@ -1,7 +1,7 @@
 using System;
 #if NET45
 using System.Runtime.Remoting.Messaging;
-#elif NETSTANDARD1_6
+#elif NETSTANDARD1_3
 using System.Threading;
 #endif
 
@@ -15,7 +15,7 @@ namespace Rebus.Transport
     {
 #if NET45
         const string TransactionContextKey = "rebus2-current-transaction-context";
-#elif NETSTANDARD1_6
+#elif NETSTANDARD1_3
         static readonly AsyncLocal<ITransactionContext> AsyncLocalTxContext = new AsyncLocal<ITransactionContext>();
 #endif
 
@@ -24,7 +24,7 @@ namespace Rebus.Transport
         /// Gets the default set function (which is using <see cref="CallContext.LogicalSetData"/> to do its thing)
         /// </summary>
         public static readonly Action<ITransactionContext> DefaultSetter = context => CallContext.LogicalSetData(TransactionContextKey, context);
-#elif NETSTANDARD1_6
+#elif NETSTANDARD1_3
         /// <summary>
         /// Gets the default set function (which is using <see cref="System.Threading.AsyncLocal{T}"/> to do its thing)
         /// </summary>
@@ -36,7 +36,7 @@ namespace Rebus.Transport
         /// Gets the default set function (which is using <see cref="CallContext.LogicalGetData"/> to do its thing)
         /// </summary>
         public static readonly Func<ITransactionContext> DefaultGetter = () => CallContext.LogicalGetData(TransactionContextKey) as ITransactionContext;
-#elif NETSTANDARD1_6
+#elif NETSTANDARD1_3
         /// <summary>
         /// Gets the default set function (which is using <see cref="System.Threading.AsyncLocal{T}"/> to do its thing)
         /// </summary>

--- a/Rebus/Workers/ThreadPoolBased/ThreadPoolWorker.cs
+++ b/Rebus/Workers/ThreadPoolBased/ThreadPoolWorker.cs
@@ -166,7 +166,7 @@ namespace Rebus.Workers.ThreadPoolBased
             }
 #if NET45
             catch (ThreadAbortException exception)
-#elif NETSTANDARD1_6
+#elif NETSTANDARD1_3
             catch (OperationCanceledException exception)
 #endif
             {


### PR DESCRIPTION
Hey bro, sup?

I've managed to bump the target framework version for .NET Standard down to v1.3.

Unfortunately, "STT" (System.Threading.Thread) libs aren't available in .NET Standard v1.0-v1.2, so I'm guessing that 1.3 is the lowest we can go with.

"Environment.MachineName" isn't available either, so I replaced these occurrences with a small "hack" that I found out in a SO question. Not sure if there's anything other than this hack available too.

Other than that, had to bump NUnit version up to 3.7.1, and add some other MS package references.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
