### PR TITLE
Single access sagas

### DIFF
--- a/Rebus/Config/RebusConfigurer.cs
+++ b/Rebus/Config/RebusConfigurer.cs
@@ -227,7 +227,7 @@ namespace Rebus.Config
                 return new SimpleRetryStrategy(simpleRetryStrategySettings, errorTracker, errorHandler);
             });
 
-			PossiblyRegisterDefault(c => new SemaphoreSagaLockProvider());
+			PossiblyRegisterDefault<ISagaLockProvider>(c => new SemaphoreSagaLockProvider());
 
             PossiblyRegisterDefault(c => new SimpleRetryStrategySettings());
 

--- a/Rebus/Config/RebusConfigurer.cs
+++ b/Rebus/Config/RebusConfigurer.cs
@@ -20,6 +20,7 @@ using Rebus.Retry.Simple;
 using Rebus.Routing;
 using Rebus.Routing.TypeBased;
 using Rebus.Sagas;
+using Rebus.Sagas.SingleAccess;
 using Rebus.Serialization;
 using Rebus.Serialization.Json;
 using Rebus.Subscriptions;
@@ -225,6 +226,8 @@ namespace Rebus.Config
                 var errorHandler = c.Get<IErrorHandler>();
                 return new SimpleRetryStrategy(simpleRetryStrategySettings, errorTracker, errorHandler);
             });
+
+			PossiblyRegisterDefault(c => new SemaphoreSagaLockProvider());
 
             PossiblyRegisterDefault(c => new SimpleRetryStrategySettings());
 

--- a/Rebus/Injection/Injectionist.cs
+++ b/Rebus/Injection/Injectionist.cs
@@ -210,7 +210,7 @@ namespace Rebus.Injection
 
                 if (!_resolvers.ContainsKey(serviceType))
                 {
-                    throw new ResolutionException("Could not find resolver for {serviceType}");
+                    throw new ResolutionException($"Could not find resolver for {serviceType}");
                 }
 
                 if (!_decoratorDepth.ContainsKey(serviceType))

--- a/Rebus/Sagas/SingleAccess/ISagaLock.cs
+++ b/Rebus/Sagas/SingleAccess/ISagaLock.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Rebus.Sagas;
+
+namespace Rebus.Sagas.SingleAccess
+{
+	/// <summary>
+	/// Defines an interface for acquiring a lock on a <seealso cref="Saga{TSagaData}"/>. Implementors should release the lock, if acquired, on disposal
+	/// </summary>
+    public interface ISagaLock : IDisposable
+	{
+		/// <summary>
+		/// Attempt to acquire a lock. If the lock was successfully acquired return <c>true</c>. If the lock could not be acquired returns <c>false</c>
+		/// </summary>
+	    Task<bool> TryAcquire();
+    }
+}

--- a/Rebus/Sagas/SingleAccess/ISagaLockProvider.cs
+++ b/Rebus/Sagas/SingleAccess/ISagaLockProvider.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Rebus.Sagas.SingleAccess
+{
+	/// <summary>
+	/// Interface for providing a lock on a saga
+	/// </summary>
+    public interface ISagaLockProvider
+	{
+		/// <summary>
+		/// Acquire a <seealso cref="ISagaLock"/> that can provide mutual exclusion semantics to a given saga
+		/// </summary>
+		/// <param name="sagaCorrelationId">The correlation identifier of the saga the lock is requested for. Implementors would usually use this to key a lock specific to this saga</param>
+		/// <returns>A <seealso cref="ISagaLock"/> that can be acquired for this saga</returns>
+	    Task<ISagaLock> LockFor(object sagaCorrelationId);
+    }
+}

--- a/Rebus/Sagas/SingleAccess/ISingleAccessSaga.cs
+++ b/Rebus/Sagas/SingleAccess/ISingleAccessSaga.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Rebus.Sagas;
+
+namespace Rebus.Sagas.SingleAccess
+{
+	/// <summary>
+	/// Marker interface used to identify a <seealso cref="Saga{TSagaData}"/> implementation as requiring single handling across all workers
+	/// </summary>
+    public interface ISingleAccessSaga
+    {
+    }
+}

--- a/Rebus/Sagas/SingleAccess/SemaphoreSagaLock.cs
+++ b/Rebus/Sagas/SingleAccess/SemaphoreSagaLock.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Rebus.Sagas.SingleAccess;
+
+namespace Rebus.Sagas.SingleAccess
+{
+	/// <summary>
+	/// An implementation of <seealso cref="ISagaLock"/> which uses a machine wide <seealso cref="Semaphore"/> to provide single access saga controls to a single machine. If you have multiple worker machines you will need to use a distributed locking mechanism
+	/// </summary>
+    public class SemaphoreSagaLock : ISagaLock
+    {
+	    private readonly Semaphore _semaphore;
+	    private bool _acquired = false;
+
+		/// <summary>
+		/// Constructs a new instance of the lock and creates a system wide semaphore named <paramref name="semaphoreName"/>
+		/// </summary>
+	    public SemaphoreSagaLock(string semaphoreName)
+	    {
+		    _semaphore = new Semaphore(1, 1, semaphoreName);
+	    }
+
+		/// <summary>
+		/// Dispose of any resources and free the semaphore if it has been acquired
+		/// </summary>
+	    public void Dispose()
+	    {
+		    if (_acquired == true)
+		    {
+			    _semaphore.Release();
+		    }
+		    _semaphore.Dispose();
+	    }
+
+	    /// <summary>
+	    /// Attempt to acquire a lock. If the lock was successfully acquired return <c>true</c>. If the lock could not be acquired returns <c>false</c>
+	    /// </summary>
+		public Task<bool> TryAcquire()
+	    {
+		    if (_acquired == false)
+		    {
+			    _acquired = _semaphore.WaitOne(TimeSpan.FromMilliseconds(50));
+		    }
+		    return Task.FromResult(_acquired);
+	    }
+	}
+}

--- a/Rebus/Sagas/SingleAccess/SemaphoreSagaLockProvider.cs
+++ b/Rebus/Sagas/SingleAccess/SemaphoreSagaLockProvider.cs
@@ -1,0 +1,21 @@
+﻿using System.Threading.Tasks;
+
+namespace Rebus.Sagas.SingleAccess
+{
+	/// <summary>
+	/// An implementation of <seealso cref="ISagaLockProvider"/> which uses a machine wide <seealso cref="System.Threading.Semaphore"/>
+	/// <remarks>Note: This will only provide single access saga protection for a single machine. If there are multiple worker machines you will need to use a distributed locking system</remarks>
+	/// </summary>
+    public class SemaphoreSagaLockProvider : ISagaLockProvider
+    {
+	    /// <summary>
+	    /// Acquire a <seealso cref="ISagaLock"/> that can provide mutual exclusion semantics to a given saga
+	    /// </summary>
+	    /// <param name="sagaCorrelationId">The correlation identifier of the saga the lock is requested for. Implementors would usually use this to key a lock specific to this saga</param>
+	    /// <returns>A <seealso cref="ISagaLock"/> that can be acquired for this saga</returns>
+	    public Task<ISagaLock> LockFor(object sagaCorrelationId)
+		{
+		    return Task.FromResult<ISagaLock>(new SemaphoreSagaLock($"rbs2-saga-lock-{sagaCorrelationId}"));
+	    }
+	}
+}

--- a/Rebus/Sagas/SingleAccess/SingleAccessSagaConfigurationExtensions.cs
+++ b/Rebus/Sagas/SingleAccess/SingleAccessSagaConfigurationExtensions.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Rebus.Bus;
+using Rebus.Config;
+using Rebus.Exceptions;
+using Rebus.Logging;
+using Rebus.Pipeline;
+
+namespace Rebus.Sagas.SingleAccess
+{
+	/// <summary>
+	/// Configuration extension for enabling single access saga feature. This feature ensures only one message from a saga is processed
+	/// at a time.
+	/// </summary>
+	public static class SingleAccessSagaConfigurationExtensions
+    {
+		/// <summary>
+		/// Enables single access sagas. When enabled saga handlers can be tagged with <seealso cref="ISingleAccessSaga"/> which will
+		/// require pessimistic locks to be taken to ensure mutual exclusion whilst executing all handlers for the saga. This is useful
+		/// if you have sagas that are chatty, have a high number of workers/threads, but processing of the saga uses valuable resources
+		/// (CPU, cost, limited number of external API calls) and you want to ensure that a <seealso cref="ConcurrencyException"/>
+		/// is not thrown causing resources to be wasted
+		/// </summary>
+		/// <remarks>Note: If you have multiple worker machines you will need to register a suitable <seealso cref="ISagaLockProvider"/></remarks>
+	    public static void EnableSingleAccessSagas(this OptionsConfigurer configurer)
+		{
+			configurer.Decorate<IPipeline>(
+				c => 
+				{
+					IRebusLoggerFactory logger = c.Get<IRebusLoggerFactory>();
+					IPipeline pipeline = c.Get<IPipeline>();
+					PipelineStepInjector injector = new PipelineStepInjector(pipeline);
+					ISagaStorage storage = c.Get<ISagaStorage>();
+					ISagaLockProvider lockProvider = c.Get<ISagaLockProvider>();
+					Func<IBus> busFactory = c.Get<IBus>;
+
+					SingleAccessSagaIncomingStep incomingStep = new SingleAccessSagaIncomingStep(logger.GetLogger<SingleAccessSagaIncomingStep>(), busFactory, lockProvider, storage);
+					injector.OnReceive(incomingStep, PipelineRelativePosition.Before, typeof(LoadSagaDataStep));
+						
+					return injector;
+				}
+			);
+	    }
+    }
+}

--- a/Rebus/Sagas/SingleAccess/SingleAccessSagaIncomingStep.cs
+++ b/Rebus/Sagas/SingleAccess/SingleAccessSagaIncomingStep.cs
@@ -115,6 +115,7 @@ Note: this may cause message reordering")]
 			catch (Exception ex)
 			{
 				_log.Error(ex, "Error during processing of single access sagas - will revert any locks");
+				throw;
 			}
 			finally
 			{

--- a/Rebus/Sagas/SingleAccess/SingleAccessSagaIncomingStep.cs
+++ b/Rebus/Sagas/SingleAccess/SingleAccessSagaIncomingStep.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Rebus.Bus;
+using Rebus.Logging;
+using Rebus.Messages;
+using Rebus.Pipeline;
+using Rebus.Pipeline.Receive;
+
+namespace Rebus.Sagas.SingleAccess {
+	/// <summary>
+	/// Incoming pipeline step that checks to see if a single access saga is being processed. If it is locks are acquired for each of 
+	/// the message handlers the saga will encounter before the pipeline proceeds. If they cannot be acquired then the message is 
+	/// deferred
+	/// </summary>
+	[StepDocumentation(@"Checks to see if a message participates in sagas and if any of those are marked as being single access.
+
+If they are then locks are acquired for each single access handler the message will encounter. If all locks are not acquired then the
+message will be deferred for later processing.
+
+Note: this may cause message reordering")]
+	public class SingleAccessSagaIncomingStep : IIncomingStep
+	{
+		private static readonly Type SingleAccessSagaType = typeof(ISingleAccessSaga);
+
+		private readonly ILog _log;
+		private readonly Lazy<IBus> _bus;
+		private readonly ISagaLockProvider _sagaLockProvider;
+		private readonly ISagaStorage _sagaStorage;
+
+		/// <summary>
+		/// Constructs the step
+		/// </summary>
+		public SingleAccessSagaIncomingStep(ILog log, Func<IBus> busFactory, ISagaLockProvider sagaLockProvider, ISagaStorage sagaStorage)
+		{
+			_log = log;
+			_bus = new Lazy<IBus>(busFactory, true);
+			_sagaLockProvider = sagaLockProvider;
+			_sagaStorage = sagaStorage;
+		}
+
+		/// <summary>
+		/// Inspects the message being processed and if any of its handlers have requested single access to the saga then acquires a lock on the saga. If a lock cannot be acquired the message is deferred until a later time.
+		/// </summary>
+		/// <param name="context"></param>
+		/// <param name="next"></param>
+		/// <returns></returns>
+		public async Task Process(IncomingStepContext context, Func<Task> next)
+		{
+			List<HandlerInvoker> singleAccessHandlers = context.Load<HandlerInvokers>()
+				.Where(hi => hi.HasSaga)
+				.Where(hi => SingleAccessSagaType.IsInstanceOfType(hi.Handler))
+				.ToList();
+
+			if (singleAccessHandlers.Any() == false)
+			{
+				await next();
+				return;
+			}
+
+			SagaHelper helper = new SagaHelper();
+			Message message = context.Load<Message>();
+			object body = message.Body;
+
+			_log.Debug($"{message.GetMessageLabel()} has {singleAccessHandlers.Count} single access message handlers");
+
+
+			List<ISagaLock> locks = new List<ISagaLock>(singleAccessHandlers.Count);
+			bool allLocksAcquired = true;
+
+			try
+			{
+				foreach (HandlerInvoker sagaInvoker in singleAccessHandlers)
+				{
+					SagaDataCorrelationProperties props = helper.GetCorrelationProperties(body, sagaInvoker.Saga);
+					IEnumerable<CorrelationProperty> propsForMessage = props.ForMessage(body);
+
+					foreach (CorrelationProperty correlationProperty in propsForMessage)
+					{
+						object correlationId = correlationProperty.ValueFromMessage(MessageContext.Current, body);
+						ISagaData sagaData = await _sagaStorage.Find(sagaInvoker.Saga.GetSagaDataType(), correlationProperty.PropertyName, correlationId);
+						if ((sagaData == null) && (sagaInvoker.CanBeInitiatedBy(body.GetType()) == false))
+						{
+							_log.Debug($"No saga data for {message.GetMessageLabel()} and the saga cannot be initiated by this message. Skipping lock.");
+							continue;
+						}
+
+						ISagaLock slock = await _sagaLockProvider.LockFor(correlationId);
+						locks.Add(slock);
+						if (await slock.TryAcquire() == true)
+						{
+							continue;
+						}
+
+						_log.Debug($"{message.GetMessageLabel()} could not acquire a saga lock for {correlationId} to process {sagaInvoker.Handler.GetType().FullName}");
+						allLocksAcquired = false;
+						break;
+					}
+				}
+
+				if (allLocksAcquired == true)
+				{
+					await next();
+				}
+				else
+				{
+					_log.Info($"{message.GetMessageLabel()} could not have all required locks acquired. Deferring for later processing");
+
+					Random random = new Random();
+					await _bus.Value.Advanced.TransportMessage.Defer(TimeSpan.FromSeconds(random.Next(5, 10)));
+				}
+			}
+			catch (Exception ex)
+			{
+				_log.Error(ex, "Error during processing of single access sagas - will revert any locks");
+			}
+			finally
+			{
+				foreach (ISagaLock slock in locks)
+				{
+					slock.Dispose();
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Introduces the concept of Single Access Sagas. These are sagas for which only one handler will execute at once. To enable these;

```C#
RebusConfigurer config = Configure.With(...)
config.EnableSingleAccessSagas()
```

This inserts a `SingleAccessSagaIncominbgStep` into the incoming pipeline before the `LoadSagaDataStep`. It will inspect all of the handlers for the incoming message and see if any of them have `HasSaga == true` and are an instance of `ISingleAccessSaga`. If no such handler satisfies these conditions then the message pipeline continues as normal.

```C#

public class MyCPUIntensiveAndChattySaga : Saga<MySagaType>, ISingleAccessSaga 
{
  // ...
}

```

If one or more handler *does* satisfy these conditions then all of the correlation properties are inspected for each `ISingleAccessSaga` message handler and correlation property. For each correlation property the ``ISagaLockProvider` requests a `ISagaLock` for that property value and the lock is attempted to be attained. If all locks can be attained then message processing continues as normal.

If not all locks were obtained then the message will be deferred for 5 - 10 seconds. **NOTE**: This means that the queue ordering may be disturbed. In practical applications this shouldn't be an issue. Also the time for deferral / strategy for deferral should probably be pushed into a new dependency.

This also comes with a `SemaphoreSagaLockProvider` / `SemaphoreSagaLock` which uses a machine wide semaphore. If your setup has more than one worker machine then you will need to implement and register a your own `ISagaLockProvider` implementation which supports a distributed locking system (eg. Redis Locks, SQL Server App Locks, etc).

For the full context of this see https://github.com/rebus-org/Rebus/issues/341

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
