### PR TITLE
FileSystemTransport now correctly supports OneWayClient

### DIFF
--- a/Rebus/Transport/FileSystem/FileSystemTransportConfigurationExtensions.cs
+++ b/Rebus/Transport/FileSystem/FileSystemTransportConfigurationExtensions.cs
@@ -38,6 +38,7 @@ namespace Rebus.Transport.FileSystem
             if (baseDirectory == null) throw new ArgumentNullException(nameof(baseDirectory));
 
             configurer.Register(context => new FileSystemTransport(baseDirectory, null));
+            OneWayClientBackdoor.ConfigureOneWayClient(configurer);
         }
     }
 }


### PR DESCRIPTION
The FileSystemTransport has a UseFileSystemAsOneWayClient extension method, but it's currently not working, since it does not update the configuration correctly. This pull request adds the vital missing piece.