### PR TITLE
Fix await build warning in saga tests

### DIFF
--- a/Rebus.Tests/Sagas/TestSagaInstanceLocking.cs
+++ b/Rebus.Tests/Sagas/TestSagaInstanceLocking.cs
@@ -159,7 +159,7 @@ Bummer dude.");
                     Data.PendingReplies.Add(replyId);
                 }
 
-                _sagaWasInitiated.Set();
+                await Task.Run(() => _sagaWasInitiated.Set());
             }
 
             public async Task Handle(SimulateReply message)


### PR DESCRIPTION
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.

Fixed build warning in Rebus.Test project