### PR TITLE
New custom step to allow failed messages to go "directly" to error queue

### DIFF
--- a/Rebus.Tests/Integration/TestFailFast.cs
+++ b/Rebus.Tests/Integration/TestFailFast.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Rebus.Activation;
+using Rebus.Bus;
+using Rebus.Config;
+using Rebus.Exceptions;
+using Rebus.Extensions;
+using Rebus.Logging;
+using Rebus.Messages;
+using Rebus.Retry.Simple;
+using Rebus.Routing.TypeBased;
+using Rebus.Tests.Contracts;
+using Rebus.Tests.Contracts.Extensions;
+using Rebus.Transport.InMem;
+using Rebus.Retry.FailFast;
+
+#pragma warning disable 1998
+
+namespace Rebus.Tests.Integration
+{
+    [TestFixture]
+    public class TestFailFast : FixtureBase
+    {
+        static readonly string InputQueueName = TestConfig.GetName($"test.rebus2.retries.input@{GetMachineName()}");
+        static readonly string ErrorQueueName = TestConfig.GetName("rebus2.error");
+
+        BuiltinHandlerActivator _handlerActivator;
+        IBus _bus;
+        InMemNetwork _network;
+
+        void InitializeBus(int numberOfRetries, IFailFastChecker failFastChecker = null)
+        {
+            _network = new InMemNetwork();
+
+            _handlerActivator = new BuiltinHandlerActivator();
+
+            _bus = Configure.With(_handlerActivator)
+                .Logging(l => l.Console(minLevel: LogLevel.Warn))
+                .Transport(t => t.UseInMemoryTransport(_network, InputQueueName))
+                .Routing(r => r.TypeBased().Map<string>(InputQueueName))
+                .Options(o =>
+                {
+                    o.SimpleRetryStrategy(maxDeliveryAttempts: numberOfRetries, errorQueueAddress: ErrorQueueName);
+                    if (failFastChecker != null)
+                    {
+                        o.Register(_ => failFastChecker);
+                    }
+                })
+                .Start();
+
+            Using(_bus);
+        }
+
+        [Test]
+        public async Task ItWorks()
+        {
+            const int numberOfRetries = 5;
+
+            InitializeBus(numberOfRetries);
+
+            var attemptedDeliveries = 0;
+
+            _handlerActivator.Handle<string>(async _ =>
+            {
+                Interlocked.Increment(ref attemptedDeliveries);
+                throw new FailFastException("omgwtf!");
+            });
+
+            await _bus.Send("hej");
+
+            var failedMessage = await _network.WaitForNextMessageFrom(ErrorQueueName);
+
+            Assert.That(attemptedDeliveries, Is.EqualTo(1));
+            Assert.That(failedMessage.Headers.GetValue(Headers.ErrorDetails), Contains.Substring($"{numberOfRetries} unhandled exceptions"));
+            Assert.That(failedMessage.Headers.GetValue(Headers.SourceQueue), Is.EqualTo(InputQueueName));
+        }
+
+        [Test]
+        public async Task ItUsesSimpleRetryStrategyWhenCustomException()
+        {
+            const int numberOfRetries = 5;
+
+            InitializeBus(numberOfRetries);
+
+            var attemptedDeliveries = 0;
+
+            _handlerActivator.Handle<string>(async _ =>
+            {
+                Interlocked.Increment(ref attemptedDeliveries);
+                throw new InvalidOperationException("omgwtf!");
+            });
+
+            await _bus.Send("hej");
+
+            var failedMessage = await _network.WaitForNextMessageFrom(ErrorQueueName);
+
+            Assert.That(attemptedDeliveries, Is.EqualTo(numberOfRetries));
+            Assert.That(failedMessage.Headers.GetValue(Headers.ErrorDetails), Contains.Substring($"{numberOfRetries} unhandled exceptions"));
+            Assert.That(failedMessage.Headers.GetValue(Headers.SourceQueue), Is.EqualTo(InputQueueName));
+        }
+
+        [Test]
+        public async Task CanConfigureCustomFailFastChecker()
+        {
+            const int numberOfRetries = 5;
+
+            InitializeBus(numberOfRetries, new CustomFailFastChecker());
+
+            var attemptedDeliveries = 0;
+
+            _handlerActivator.Handle<string>(async _ =>
+            {
+                Interlocked.Increment(ref attemptedDeliveries);
+                throw new InvalidOperationException("omgwtf!");
+            });
+
+            await _bus.Send("hej");
+
+            var failedMessage = await _network.WaitForNextMessageFrom(ErrorQueueName);
+
+            Assert.That(attemptedDeliveries, Is.EqualTo(1));
+            Assert.That(failedMessage.Headers.GetValue(Headers.ErrorDetails), Contains.Substring($"{numberOfRetries} unhandled exceptions"));
+            Assert.That(failedMessage.Headers.GetValue(Headers.SourceQueue), Is.EqualTo(InputQueueName));
+        }
+
+        private class CustomFailFastChecker : IFailFastChecker
+        {
+            public bool ShouldFailFast(string messageId, Exception exception)
+            {
+                return exception is InvalidOperationException;
+            }
+        }
+
+        private static string GetMachineName()
+        {
+#if NETSTANDARD1_3
+            return Environment.GetEnvironmentVariable("COMPUTERNAME") ?? Environment.GetEnvironmentVariable("HOSTNAME");
+#else
+            return Environment.MachineName;
+#endif
+        }
+    }
+}

--- a/Rebus/Exceptions/FailFastException.cs
+++ b/Rebus/Exceptions/FailFastException.cs
@@ -1,0 +1,42 @@
+﻿using System;
+#if NET45
+using System.Runtime.Serialization;
+#endif
+
+namespace Rebus.Exceptions
+{
+    /// <summary>
+    /// Fail-fast exception bypasses the retry logic and goes to the error queue directly
+    /// </summary>
+#if NET45
+    [Serializable]
+#endif
+    public class FailFastException : Exception
+    {
+        /// <summary>
+        /// Constructs the exception with the given message
+        /// </summary>
+        public FailFastException(string message)
+            :base(message)
+        {
+        }
+
+        /// <summary>
+        /// Constructs the exception with the given message and inner exception
+        /// </summary>
+        public FailFastException(Exception innerException, string message)
+            :base(message, innerException)
+        {
+        }
+
+#if NET45
+        /// <summary>
+        /// Happy cross-domain serialization!
+        /// </summary>
+        public FailFastException(SerializationInfo info, StreamingContext context)
+            :base(info, context)
+        {
+        }
+#endif
+    }
+}

--- a/Rebus/Retry/FailFast/FailFastChecker.cs
+++ b/Rebus/Retry/FailFast/FailFastChecker.cs
@@ -1,0 +1,21 @@
+﻿using Rebus.Exceptions;
+using System;
+
+namespace Rebus.Retry.FailFast
+{
+    /// <summary>
+    /// Implementation of <seealso cref="IFailFastChecker"/> that determines that if an exception is
+    /// <seealso cref=" FailFastException"/>, it should fail fast. Children of this class could
+    /// further define additional logic to check if a message with exception should fail fast.
+    /// </summary>
+    public class FailFastChecker : IFailFastChecker
+    {
+        /// <summary>
+        /// Checks if a message with exception should fail fast
+        /// </summary>
+        public virtual bool ShouldFailFast(string messageId, Exception exception)
+        {
+            return exception is FailFastException;
+        }
+    }
+}

--- a/Rebus/Retry/FailFast/FailFastStep.cs
+++ b/Rebus/Retry/FailFast/FailFastStep.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Rebus.Exceptions;
+using Rebus.Extensions;
+using Rebus.Messages;
+using Rebus.Pipeline;
+using Rebus.Transport;
+
+namespace Rebus.Retry.FailFast
+{
+    /// <summary>
+    /// Incoming message pipeline step that implements a fail-fast mechanism - if the message has failed once
+    /// with a specific exceptions, it get marked as "failed too many times". This allows the <seealso cref="Simple.SimpleRetryStrategyStep"/>
+    /// to send the message to the error queue.
+    /// </summary>
+    [StepDocumentation(@"Checks if a message has failed with specific exceptions and marks it as ""failed too many times"". 
+This allows the SimpleRetryStrategyStep to move it to the error queue.")]
+    public class FailFastStep : IIncomingStep
+    {
+        readonly IErrorTracker _errorTracker;
+        readonly IFailFastChecker _failFastChecker;
+
+        /// <summary>
+        /// Constructs the step, using the given error tracker
+        /// </summary>
+        public FailFastStep(IErrorTracker errorTracker, IFailFastChecker failFastChecker)
+        {
+            if (errorTracker == null) throw new ArgumentNullException(nameof(errorTracker));
+            if (failFastChecker == null) throw new ArgumentNullException(nameof(failFastChecker));
+
+            _errorTracker = errorTracker;
+            _failFastChecker = failFastChecker;
+        }
+
+        /// <summary>
+        /// Checks if there are any registered exceptions to the current message and
+        /// if all of them are <see cref="FailFastException"/>, then mark the message
+        /// as failed too many times.
+        /// </summary>
+        public async Task Process(IncomingStepContext context, Func<Task> next)
+        {
+            var transportMessage = context.Load<TransportMessage>();
+            var transactionContext = context.Load<ITransactionContext>();
+            var messageId = transportMessage.Headers.GetValueOrNull(Headers.MessageId);
+
+            if (!string.IsNullOrWhiteSpace(messageId))
+            {
+                var trackedExceptions = _errorTracker.GetExceptions(messageId).ToArray();
+                if (trackedExceptions.Any() && trackedExceptions.All(e => _failFastChecker.ShouldFailFast(messageId, e)))
+                {
+                    MarkAsFailedTooManyTimes(messageId, trackedExceptions.Last());
+                }
+            }
+
+            await next();
+        }
+
+        void MarkAsFailedTooManyTimes(string messageId, Exception exception)
+        {
+            while (!_errorTracker.HasFailedTooManyTimes(messageId))
+            {
+                _errorTracker.RegisterError(messageId, exception);
+            }
+        }
+    }
+}

--- a/Rebus/Retry/FailFast/IFailFastChecker.cs
+++ b/Rebus/Retry/FailFast/IFailFastChecker.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Rebus.Retry.FailFast
+{
+    /// <summary>
+    /// Service to check if a message should fail fast
+    /// </summary>
+    public interface IFailFastChecker
+    {
+        /// <summary>
+        /// Checks if a message with specific exception should fail fast
+        /// </summary>
+        bool ShouldFailFast(string messageId, Exception exception);
+    }
+}


### PR DESCRIPTION
A new incoming step `FailFastStep` checks if a message has been marked as failed with a specific exception, it sends the message directly to the error queue without retrying further. The default check happens for a custom exception of type `FailFastException`. Custom logic could be built by implementing `IFailFastChecker`.

This step uses only `IErrorTracker` and relies on its semantics (f.x., that calling `RegisterError` becomes closer to `HasFailedTooManyTimes`). This step does not take into consideration transactions as they are supposed to be abroted by `SimpleRetryStrategyStep` when the first exception has been caught. By marking the message as "failed too many times", the `SimpleRetryStrategyStep` will automatically move the message to the configured error queue.

This PR comes as a possible solution to #657

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
