### PR TITLE
Create extensibility point for topics

### DIFF
--- a/Rebus.Tests/Topic/TestDefaultTopicNameConvention.cs
+++ b/Rebus.Tests/Topic/TestDefaultTopicNameConvention.cs
@@ -1,0 +1,27 @@
+﻿using NUnit.Framework;
+using Rebus.Extensions;
+using Rebus.Topic;
+
+namespace Rebus.Tests.Topic
+{
+    [TestFixture]
+    public class TestDefaultTopicNameConvention
+    {
+        [Test]
+        public void DefaultTopicNameConventionUseGetAssExtension()
+        {
+            var convention = new DefaultTopicNameConvention();
+
+            var expected = typeof(SimpleMessage).GetSimpleAssemblyQualifiedName();
+            var actual = convention.GetTopic(typeof(SimpleMessage));
+
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+    }
+
+    public class SimpleMessage
+    {
+        public string Something { get; set; }
+
+    }
+}

--- a/Rebus/Config/RebusConfigurer.cs
+++ b/Rebus/Config/RebusConfigurer.cs
@@ -32,6 +32,8 @@ using Rebus.Transport;
 using Rebus.Workers;
 using Rebus.Workers.ThreadPoolBased;
 using Rebus.Retry.FailFast;
+using Rebus.Topic;
+
 // ReSharper disable EmptyGeneralCatchClause
 
 namespace Rebus.Config
@@ -285,6 +287,8 @@ namespace Rebus.Config
 
             PossiblyRegisterDefault<IDataBus>(c => new DisabledDataBus());
 
+            PossiblyRegisterDefault<ITopicNameConvention>(c => new DefaultTopicNameConvention());
+
             // configuration hack - keep these two bad boys around to have them available at the last moment before returning the built bus instance...
             Action startAction = null;
 
@@ -297,7 +301,8 @@ namespace Rebus.Config
                 _options,
                 c.Get<IRebusLoggerFactory>(),
                 c.Get<BusLifetimeEvents>(),
-                c.Get<IDataBus>()));
+                c.Get<IDataBus>(),
+                c.Get<ITopicNameConvention>()));
 
             // since an error during resolution does not give access to disposable instances, we need to do this
             var disposableInstancesTrackedFromInitialResolution = new ConcurrentStack<IDisposable>();

--- a/Rebus/Topic/DefaultTopicNameConvention.cs
+++ b/Rebus/Topic/DefaultTopicNameConvention.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Rebus.Extensions;
+
+namespace Rebus.Topic
+{
+    /// <summary>
+    /// Default convention to name topics
+    /// </summary>
+    public class DefaultTopicNameConvention : ITopicNameConvention
+    {
+        /// <summary>
+        /// Returns the default topic name based on type of message
+        /// </summary>
+        public string GetTopic(Type eventType)
+        {
+            return eventType.GetSimpleAssemblyQualifiedName();
+        }
+    }
+}

--- a/Rebus/Topic/ITopicNameConvention.cs
+++ b/Rebus/Topic/ITopicNameConvention.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Rebus.Topic
+{
+    /// <summary>
+    /// Defines the rules to name topics
+    /// </summary>
+    public interface ITopicNameConvention
+    {
+        /// <summary>
+        /// Returns the topic name based on type of message
+        /// </summary>
+        string GetTopic(Type eventType);
+    }
+}


### PR DESCRIPTION
These changes allows create a convention to topics names. The ideia is based on discussion #692 

The interface `ITopicNameConvention` is used to name topics and can be registered using `OptionsConfigurer`

```cs
public interface ITopicNameConvention
{
    string GetTopic(Type eventType);
}
```
The `DefaultTopicNameConvention` uses the previous pattern and is the default implementantion.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
