### PR TITLE
Made storage for saga exclusive lock configurable by using an interface

### DIFF
--- a/Rebus.Tests/Assumptions/TestLockContention.cs
+++ b/Rebus.Tests/Assumptions/TestLockContention.cs
@@ -80,13 +80,14 @@ Elapsed: {elapsed.TotalSeconds:0.0}
 
         static IEnumerable<IIncomingStep> GetSteps()
         {
-            yield return new EnforceExclusiveSagaAccessIncomingStep();
+            var handler = new HandleSagaExlusiveLockInConcurrentDictionary();
+            yield return new EnforceExclusiveSagaAccessIncomingStep(handler);
             yield return new NewEnforceExclusiveSagaAccessIncomingStep(10, CancellationToken.None);
-            yield return new EnforceExclusiveSagaAccessIncomingStep();
+            yield return new EnforceExclusiveSagaAccessIncomingStep(handler);
             yield return new NewEnforceExclusiveSagaAccessIncomingStep(20, CancellationToken.None);
-            yield return new EnforceExclusiveSagaAccessIncomingStep();
+            yield return new EnforceExclusiveSagaAccessIncomingStep(handler);
             yield return new NewEnforceExclusiveSagaAccessIncomingStep(50, CancellationToken.None);
-            yield return new EnforceExclusiveSagaAccessIncomingStep();
+            yield return new EnforceExclusiveSagaAccessIncomingStep(handler);
             yield return new NewEnforceExclusiveSagaAccessIncomingStep(100, CancellationToken.None);
         }
     }

--- a/Rebus/Sagas/Exclusive/ExclusiveAccessConfigurationExtensions.cs
+++ b/Rebus/Sagas/Exclusive/ExclusiveAccessConfigurationExtensions.cs
@@ -30,5 +30,26 @@ namespace Rebus.Sagas.Exclusive
                         .OnReceive(step, PipelineRelativePosition.Before, typeof(LoadSagaDataStep));
                 });
         }
+
+        /// <summary>
+        /// Forces exclusive using a lockhandler defined by <see cref="IHandleSagaExlusiveLock"/>
+        /// </summary>
+        public static void EnforceExclusiveAccess(this StandardConfigurer<ISagaStorage> configurer, IHandleSagaExlusiveLock locker)
+        {
+            if (configurer == null) throw new ArgumentNullException(nameof(configurer));
+
+            configurer
+                .OtherService<IPipeline>()
+                .Decorate(c =>
+                {
+                    var pipeline = c.Get<IPipeline>();
+                    //var step = new EnforceExclusiveSagaAccessIncomingStep();
+                    var cancellationToken = c.Get<CancellationToken>();
+                    var step = new EnforceExclusiveSagaAccessIncomingStep(locker);
+
+                    return new PipelineStepInjector(pipeline)
+                        .OnReceive(step, PipelineRelativePosition.Before, typeof(LoadSagaDataStep));
+                });
+        }
     }
 }

--- a/Rebus/Sagas/Exclusive/HandleSagaExlusiveLockInConcurrentDictionary.cs
+++ b/Rebus/Sagas/Exclusive/HandleSagaExlusiveLockInConcurrentDictionary.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Concurrent;
+using System.Threading.Tasks;
+
+namespace Rebus.Sagas.Exclusive
+{
+    class HandleSagaExlusiveLockInConcurrentDictionary : IHandleSagaExlusiveLock
+    {
+        readonly ConcurrentDictionary<string, string> _locks = new ConcurrentDictionary<string, string>();
+        public Task<bool> AquireLockAsync(string key)
+        {
+            return Task.FromResult(_locks.TryAdd(key, "dummy"));
+        }
+
+        public Task<bool> ReleaseLockAsync(string key)
+        {
+            return Task.FromResult(_locks.TryRemove(key, out var dummy));
+        }
+    }
+}

--- a/Rebus/Sagas/Exclusive/IHandleSagaExlusiveLock.cs
+++ b/Rebus/Sagas/Exclusive/IHandleSagaExlusiveLock.cs
@@ -2,9 +2,22 @@
 
 namespace Rebus.Sagas.Exclusive
 {
+    /// <summary>
+    /// Defines API for storing sagalocks
+    /// </summary>
     public interface IHandleSagaExlusiveLock
     {
+        /// <summary>
+        /// Aquire a lock for given key
+        /// </summary>
+        /// <param name="key">Lockingkey</param>
+        /// <returns></returns>
         Task<bool> AquireLockAsync(string key);
+        /// <summary>
+        /// Release a lock for given key
+        /// </summary>
+        /// <param name="key">Lockingkey</param>
+        /// <returns></returns>
         Task<bool> ReleaseLockAsync(string key);
 
     }

--- a/Rebus/Sagas/Exclusive/IHandleSagaExlusiveLock.cs
+++ b/Rebus/Sagas/Exclusive/IHandleSagaExlusiveLock.cs
@@ -1,0 +1,11 @@
+﻿using System.Threading.Tasks;
+
+namespace Rebus.Sagas.Exclusive
+{
+    public interface IHandleSagaExlusiveLock
+    {
+        Task<bool> AquireLockAsync(string key);
+        Task<bool> ReleaseLockAsync(string key);
+
+    }
+}


### PR DESCRIPTION
I have tried two alternative approaches for implementing "centralized-saga-locking" by storing locks in Redis. Locking in-process (as Rebus already supports) is not an option as we are running multiple workers.
The first solution is documented here https://github.com/idfy-io/rebus.redissagalock

The second one is documented in this pull request which basically introduces a simple interface for configuring where locks are stored. It would then be easy to implement this interface and store the locks in redis or some other store.

Feel free to comment or propose alternative approaches.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
