### PR TITLE
Fixed small comment typo

### DIFF
--- a/Rebus/Pipeline/PipelineStepInjector.cs
+++ b/Rebus/Pipeline/PipelineStepInjector.cs
@@ -7,7 +7,7 @@ namespace Rebus.Pipeline
 {
     /// <summary>
     /// Decorator of <see cref="IPipeline"/> that can inject one or more steps into either pipeline,
-    /// positionint the injected steps relatively to another step by its type.
+    /// position in the injected steps relatively to another step by its type.
     /// Could probably be extended with more ways of detecting "the other step" than by its concrete type.
     /// </summary>
     public class PipelineStepInjector : IPipeline


### PR DESCRIPTION
What the title says.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
