### PR TITLE
Add WillBeInvoked property to HandlerInvoker

### DIFF
--- a/Rebus/Pipeline/Receive/HandlerInvoker.cs
+++ b/Rebus/Pipeline/Receive/HandlerInvoker.cs
@@ -78,6 +78,11 @@ namespace Rebus.Pipeline.Receive
         /// not depend on it!)
         /// </summary>
         public abstract object Handler { get; }
+
+		/// <summary>
+		/// <c>true</c> if the handler will be invoked, as per normal, <c>false</c> if <see cref="SkipInvocation"/> has been called or the invoke will otherwise be skipped
+		/// </summary>
+		public abstract bool WillBeInvoked { get; }
     }
 
     /// <summary>
@@ -106,7 +111,11 @@ namespace Rebus.Pipeline.Receive
         /// </summary>
         public override object Handler => _handler;
 
-        /// <summary>
+
+	    /// <inheritdoc />
+	    public override bool WillBeInvoked => _invokeHandler;
+
+	    /// <summary>
         /// Gets whther the contained handler object has a saga
         /// </summary>
         public override bool HasSaga => _handler is Saga;


### PR DESCRIPTION
Add a `WillBeInvoked` property to `HandlerInvoker` and `HandlerInvoker<T>`. This is set to false if `SkipInvocation()` has been called on an invoker. This allows `IIncomingStep`, and other infrastructure, to act accordingly if an invoker is getting skipped.

Resolves #713 .

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
