### PR TITLE
Change IAsyncBackoffStrategy to IBackoffStrategy and implement both async and async waiting methods

### DIFF
--- a/Rebus.Tests/Backoff/TestBackoffBehaviorWhenBusy.cs
+++ b/Rebus.Tests/Backoff/TestBackoffBehaviorWhenBusy.cs
@@ -116,27 +116,44 @@ namespace Rebus.Tests.Backoff
             public IEnumerable<DateTime> WaitTimes => _waitTimes;
             public IEnumerable<DateTime> WaitNoMessageTimes => _waitNoMessageTimes;
 
-            public Task Reset()
+            public void Reset()
             {
-                return AsyncBackoffStrategy.Reset();
+                AsyncBackoffStrategy.Reset();
             }
 
-            public Task WaitNoMessage()
+            public void WaitNoMessage()
             {
                 _waitNoMessageTimes.Enqueue(DateTime.UtcNow);
-                return AsyncBackoffStrategy.WaitNoMessage();
+                AsyncBackoffStrategy.WaitNoMessage();
             }
 
-            public void Wait()
+	        public Task WaitNoMessageAsync()
+	        {
+		        _waitNoMessageTimes.Enqueue(DateTime.UtcNow);
+		        return AsyncBackoffStrategy.WaitNoMessageAsync();
+	        }
+
+			public void Wait()
+			{
+				_waitTimes.Enqueue(DateTime.UtcNow);
+				AsyncBackoffStrategy.Wait();
+			}
+
+	        public Task WaitAsync()
+	        {
+		        _waitTimes.Enqueue(DateTime.UtcNow);
+		        return AsyncBackoffStrategy.WaitAsync();
+	        }
+
+			public void WaitError()
             {
-                _waitTimes.Enqueue(DateTime.UtcNow);
-                AsyncBackoffStrategy.Wait();
+                AsyncBackoffStrategy.WaitError();
             }
 
-            public Task WaitError()
-            {
-                return AsyncBackoffStrategy.WaitError();
-            }
+	        public Task WaitErrorAsync()
+	        {
+		        return AsyncBackoffStrategy.WaitErrorAsync();
+	        }
         }
-    }
+	}
 }

--- a/Rebus.Tests/Backoff/TestBackoffBehaviorWhenBusy.cs
+++ b/Rebus.Tests/Backoff/TestBackoffBehaviorWhenBusy.cs
@@ -43,10 +43,10 @@ namespace Rebus.Tests.Backoff
                     o.SetBackoffTimes(TimeSpan.FromSeconds(0.2));
 
                     // install the snitch
-                    o.Decorate<IAsyncBackoffStrategy>(c =>
+                    o.Decorate<IBackoffStrategy>(c =>
                     {
-                        var backoffStrategy = c.Get<IAsyncBackoffStrategy>();
-                        _snitch.AsyncBackoffStrategy = backoffStrategy;
+                        var backoffStrategy = c.Get<IBackoffStrategy>();
+                        _snitch.BackoffStrategy = backoffStrategy;
                         return _snitch;
                     });
 
@@ -106,53 +106,53 @@ namespace Rebus.Tests.Backoff
                 seconds.Select(time => $"{time}: {new string('.', waitsPerSecond.GetValueOrDefault(time))}{new string('*', waitNoMessagesPerSecond.GetValueOrDefault(time))}")));
         }
 
-        class BackoffSnitch : IAsyncBackoffStrategy
+        class BackoffSnitch : IBackoffStrategy
         {
             readonly ConcurrentQueue<DateTime> _waitTimes = new ConcurrentQueue<DateTime>();
             readonly ConcurrentQueue<DateTime> _waitNoMessageTimes = new ConcurrentQueue<DateTime>();
 
-            public IAsyncBackoffStrategy AsyncBackoffStrategy { get; set; }
+            public IBackoffStrategy BackoffStrategy { get; set; }
 
             public IEnumerable<DateTime> WaitTimes => _waitTimes;
             public IEnumerable<DateTime> WaitNoMessageTimes => _waitNoMessageTimes;
 
             public void Reset()
             {
-                AsyncBackoffStrategy.Reset();
+                BackoffStrategy.Reset();
             }
 
             public void WaitNoMessage()
             {
                 _waitNoMessageTimes.Enqueue(DateTime.UtcNow);
-                AsyncBackoffStrategy.WaitNoMessage();
+                BackoffStrategy.WaitNoMessage();
             }
 
 	        public Task WaitNoMessageAsync()
 	        {
 		        _waitNoMessageTimes.Enqueue(DateTime.UtcNow);
-		        return AsyncBackoffStrategy.WaitNoMessageAsync();
+		        return BackoffStrategy.WaitNoMessageAsync();
 	        }
 
 			public void Wait()
 			{
 				_waitTimes.Enqueue(DateTime.UtcNow);
-				AsyncBackoffStrategy.Wait();
+				BackoffStrategy.Wait();
 			}
 
 	        public Task WaitAsync()
 	        {
 		        _waitTimes.Enqueue(DateTime.UtcNow);
-		        return AsyncBackoffStrategy.WaitAsync();
+		        return BackoffStrategy.WaitAsync();
 	        }
 
 			public void WaitError()
             {
-                AsyncBackoffStrategy.WaitError();
+                BackoffStrategy.WaitError();
             }
 
 	        public Task WaitErrorAsync()
 	        {
-		        return AsyncBackoffStrategy.WaitErrorAsync();
+		        return BackoffStrategy.WaitErrorAsync();
 	        }
         }
 	}

--- a/Rebus.Tests/Workers/TestDefaultAsyncBackoffStrategy.cs
+++ b/Rebus.Tests/Workers/TestDefaultAsyncBackoffStrategy.cs
@@ -10,8 +10,44 @@ namespace Rebus.Tests.Workers
     [TestFixture]
     public class TestDefaultAsyncBackoffStrategy : FixtureBase
     {
-        [Test]
-        public async Task BacksOffAsItShould()
+	    [Test]
+	    public void WaitDoesPerformDoesPause()
+	    {
+			// Arrange
+		    var backoffStrategy = new DefaultAsyncBackoffStrategy(new[]
+		    {
+			    TimeSpan.FromMilliseconds(500)
+		    });
+
+			// Act
+		    var stopwatch = Stopwatch.StartNew();
+		    backoffStrategy.Wait();
+		    stopwatch.Stop();
+
+			// Assert
+			Assert.GreaterOrEqual(stopwatch.Elapsed, TimeSpan.FromMilliseconds(500));
+	    }
+
+	    [Test]
+	    public async Task WaitAsyncDoesPause()
+	    {
+		    // Arrange
+		    var backoffStrategy = new DefaultAsyncBackoffStrategy(new[]
+		    {
+			    TimeSpan.FromMilliseconds(500)
+		    });
+
+		    // Act
+		    var stopwatch = Stopwatch.StartNew();
+		    await backoffStrategy.WaitAsync();
+		    stopwatch.Stop();
+
+		    // Assert
+		    Assert.GreaterOrEqual(stopwatch.Elapsed, TimeSpan.FromMilliseconds(500));
+	    }
+
+		[Test]
+        public void BacksOffAsItShould()
         {
             var backoffStrategy = new DefaultAsyncBackoffStrategy(new[]
             {

--- a/Rebus.Tests/Workers/TestDefaultBackoffStrategy.cs
+++ b/Rebus.Tests/Workers/TestDefaultBackoffStrategy.cs
@@ -8,13 +8,13 @@ using Rebus.Workers.ThreadPoolBased;
 namespace Rebus.Tests.Workers
 {
     [TestFixture]
-    public class TestDefaultAsyncBackoffStrategy : FixtureBase
+    public class TestDefaultBackoffStrategy : FixtureBase
     {
 	    [Test]
 	    public void WaitDoesPerformDoesPause()
 	    {
 			// Arrange
-		    var backoffStrategy = new DefaultAsyncBackoffStrategy(new[]
+		    var backoffStrategy = new DefaultBackoffStrategy(new[]
 		    {
 			    TimeSpan.FromMilliseconds(500)
 		    });
@@ -32,7 +32,7 @@ namespace Rebus.Tests.Workers
 	    public async Task WaitAsyncDoesPause()
 	    {
 		    // Arrange
-		    var backoffStrategy = new DefaultAsyncBackoffStrategy(new[]
+		    var backoffStrategy = new DefaultBackoffStrategy(new[]
 		    {
 			    TimeSpan.FromMilliseconds(500)
 		    });
@@ -49,7 +49,7 @@ namespace Rebus.Tests.Workers
 		[Test]
         public void BacksOffAsItShould()
         {
-            var backoffStrategy = new DefaultAsyncBackoffStrategy(new[]
+            var backoffStrategy = new DefaultBackoffStrategy(new[]
             {
                 TimeSpan.FromMilliseconds(100), 
                 TimeSpan.FromMilliseconds(500), 

--- a/Rebus/Backoff/BackoffConfigurationExtensions.cs
+++ b/Rebus/Backoff/BackoffConfigurationExtensions.cs
@@ -41,7 +41,7 @@ namespace Rebus.Backoff
                 throw new ArgumentException("Please specify at least one TimeSpan when you customize the backoff times! You could for example specify new[] { TimeSpan.FromSeconds(0.5), TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(5) } in order to wait 0.5s and 1s during the first two seconds of inactivity, and then 5 seconds poll interval forever thereafter");
             }
 
-            configurer.Register<IAsyncBackoffStrategy>(c => new DefaultAsyncBackoffStrategy(list));
+            configurer.Register<IBackoffStrategy>(c => new DefaultBackoffStrategy(list));
         }
     }
 }

--- a/Rebus/Config/RebusConfigurer.cs
+++ b/Rebus/Config/RebusConfigurer.cs
@@ -192,7 +192,7 @@ namespace Rebus.Config
                 return new DefaultPipelineInvokerNew(pipeline);
             });
 
-            PossiblyRegisterDefault<IAsyncBackoffStrategy>(c =>
+            PossiblyRegisterDefault<IBackoffStrategy>(c =>
             {
                 var backoffTimes = new[]
                 {
@@ -203,7 +203,7 @@ namespace Rebus.Config
                     Enumerable.Repeat(TimeSpan.FromMilliseconds(250), 1)
                 };
 
-                return new DefaultAsyncBackoffStrategy(backoffTimes.SelectMany(e => e));
+                return new DefaultBackoffStrategy(backoffTimes.SelectMany(e => e));
             });
 
             PossiblyRegisterDefault<IWorkerFactory>(c =>
@@ -213,7 +213,7 @@ namespace Rebus.Config
                 var pipelineInvoker = c.Get<IPipelineInvoker>();
                 var options = c.Get<Options>();
                 var busLifetimeEvents = c.Get<BusLifetimeEvents>();
-                var backoffStrategy = c.Get<IAsyncBackoffStrategy>();
+                var backoffStrategy = c.Get<IBackoffStrategy>();
                 return new ThreadPoolWorkerFactory(transport, rebusLoggerFactory, pipelineInvoker, options, c.Get<RebusBus>, busLifetimeEvents, backoffStrategy);
             });
 

--- a/Rebus/Workers/ThreadPoolBased/DefaultAsyncBackoffStrategy.cs
+++ b/Rebus/Workers/ThreadPoolBased/DefaultAsyncBackoffStrategy.cs
@@ -33,23 +33,40 @@ namespace Rebus.Workers.ThreadPoolBased
             InnerWait();
         }
 
-        /// <inheritdoc />
-        public Task WaitNoMessage()
+	    /// <inheritdoc />
+	    public Task WaitAsync()
+	    {
+		    return InnerWaitAsync();
+	    }
+
+		/// <inheritdoc />
+		public void WaitNoMessage()
+	    {
+		    InnerWait();
+	    }
+
+		/// <inheritdoc />
+		public Task WaitNoMessageAsync()
         {
             return InnerWaitAsync();
         }
 
-        /// <inheritdoc />
-        public async Task WaitError()
-        {
-            await Task.Delay(TimeSpan.FromSeconds(5));
-        }
+	    /// <inheritdoc />
+	    public void WaitError()
+	    {
+			Thread.Sleep(TimeSpan.FromSeconds(5));
+	    }
+
+		/// <inheritdoc />
+		public async Task WaitErrorAsync()
+	    {
+		    await Task.Delay(TimeSpan.FromSeconds(5));
+	    }
 
         /// <inheritdoc />
-        public Task Reset()
+        public void Reset()
         {
             Interlocked.Exchange(ref _waitTimeTicks, 0);
-	        return Task.FromResult(0);
         }
 
         async Task InnerWaitAsync()

--- a/Rebus/Workers/ThreadPoolBased/DefaultBackoffStrategy.cs
+++ b/Rebus/Workers/ThreadPoolBased/DefaultBackoffStrategy.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Rebus.Workers.ThreadPoolBased
 {
-    class DefaultAsyncBackoffStrategy : IAsyncBackoffStrategy
+    class DefaultBackoffStrategy : IBackoffStrategy
     {
         readonly TimeSpan[] _backoffTimes;
 
@@ -15,7 +15,7 @@ namespace Rebus.Workers.ThreadPoolBased
         /// <summary>
         /// Constructs the backoff strategy with the given waiting times
         /// </summary>
-        public DefaultAsyncBackoffStrategy(IEnumerable<TimeSpan> backoffTimes)
+        public DefaultBackoffStrategy(IEnumerable<TimeSpan> backoffTimes)
         {
             if (backoffTimes == null) throw new ArgumentNullException(nameof(backoffTimes));
 

--- a/Rebus/Workers/ThreadPoolBased/IAsyncBackoffStrategy.cs
+++ b/Rebus/Workers/ThreadPoolBased/IAsyncBackoffStrategy.cs
@@ -14,20 +14,37 @@ namespace Rebus.Workers.ThreadPoolBased
         /// </summary>
         void Wait();
 
-        /// <summary>
-        /// Executes the next wait operation by blocking the thread, possibly advancing the wait cursor to a different wait time for the next time.
-        /// This function is called each time no message was received.
-        /// </summary>
-        Task WaitNoMessage();
+	    /// <summary>
+	    /// Executes the next wait operation by blocking the thread, possibly advancing the wait cursor to a different wait time for the next time.
+	    /// This function is called each time a worker thread cannot continue because no more parallel operations are allowed to happen.
+	    /// </summary>
+	    Task WaitAsync();
 
-        /// <summary>
-        /// Blocks the thread for a (most likely longer) while, when an error has occurred
-        /// </summary>
-        Task WaitError();
+		/// <summary>
+		/// Executes the next wait operation by blocking the thread, possibly advancing the wait cursor to a different wait time for the next time.
+		/// This function is called each time no message was received.
+		/// </summary>
+		void WaitNoMessage();
 
 	    /// <summary>
-	    /// Resets the strategy. Is called whenever a message was received.
+	    /// Executes the next wait operation by blocking the thread, possibly advancing the wait cursor to a different wait time for the next time.
+	    /// This function is called each time no message was received.
 	    /// </summary>
-	    Task Reset();
+	    Task WaitNoMessageAsync();
+
+		/// <summary>
+		/// Blocks the thread for a (most likely longer) while, when an error has occurred
+		/// </summary>
+		void WaitError();
+
+	    /// <summary>
+	    /// Blocks the thread for a (most likely longer) while, when an error has occurred
+	    /// </summary>
+	    Task WaitErrorAsync();
+
+		/// <summary>
+		/// Resets the strategy. Is called whenever a message was received.
+		/// </summary>
+		void Reset();
     }
 }

--- a/Rebus/Workers/ThreadPoolBased/IBackoffStrategy.cs
+++ b/Rebus/Workers/ThreadPoolBased/IBackoffStrategy.cs
@@ -3,10 +3,10 @@ using System.Threading.Tasks;
 namespace Rebus.Workers.ThreadPoolBased
 {
     /// <summary>
-    /// Implements a strategy with which workers will back off in idle periods. Please note that the <see cref="IAsyncBackoffStrategy"/>
+    /// Implements a strategy with which workers will back off in idle periods. Please note that the <see cref="IBackoffStrategy"/>
     /// implementations must be reentrant!
     /// </summary>
-    public interface IAsyncBackoffStrategy
+    public interface IBackoffStrategy
     {
         /// <summary>
         /// Executes the next wait operation by blocking the thread, possibly advancing the wait cursor to a different wait time for the next time.

--- a/Rebus/Workers/ThreadPoolBased/ThreadPoolWorker.cs
+++ b/Rebus/Workers/ThreadPoolBased/ThreadPoolWorker.cs
@@ -110,11 +110,11 @@ namespace Rebus.Workers.ThreadPoolBased
                         // no need for another thread to rush in and discover that there is no message
                         //parallelOperation.Dispose();
 
-                        await _backoffStrategy.WaitNoMessage();
+                        await _backoffStrategy.WaitNoMessageAsync();
                         return;
                     }
 
-	                await _backoffStrategy.Reset();
+	                _backoffStrategy.Reset();
 
                     await ProcessMessage(context, transportMessage).ConfigureAwait(false);
                 }
@@ -144,7 +144,7 @@ namespace Rebus.Workers.ThreadPoolBased
             {
                 _log.Warn("An error occurred when attempting to receive the next message: {exception}", exception);
 
-                await _backoffStrategy.WaitError();
+                await _backoffStrategy.WaitErrorAsync();
 
                 return null;
             }

--- a/Rebus/Workers/ThreadPoolBased/ThreadPoolWorker.cs
+++ b/Rebus/Workers/ThreadPoolBased/ThreadPoolWorker.cs
@@ -21,11 +21,11 @@ namespace Rebus.Workers.ThreadPoolBased
         readonly ParallelOperationsManager _parallelOperationsManager;
         readonly RebusBus _owningBus;
         readonly Options _options;
-        readonly IAsyncBackoffStrategy _backoffStrategy;
+        readonly IBackoffStrategy _backoffStrategy;
         readonly Thread _workerThread;
         readonly ILog _log;
 
-        internal ThreadPoolWorker(string name, ITransport transport, IRebusLoggerFactory rebusLoggerFactory, IPipelineInvoker pipelineInvoker, ParallelOperationsManager parallelOperationsManager, RebusBus owningBus, Options options, IAsyncBackoffStrategy backoffStrategy)
+        internal ThreadPoolWorker(string name, ITransport transport, IRebusLoggerFactory rebusLoggerFactory, IPipelineInvoker pipelineInvoker, ParallelOperationsManager parallelOperationsManager, RebusBus owningBus, Options options, IBackoffStrategy backoffStrategy)
         {
             Name = name;
             _log = rebusLoggerFactory.GetLogger<ThreadPoolWorker>();

--- a/Rebus/Workers/ThreadPoolBased/ThreadPoolWorkerFactory.cs
+++ b/Rebus/Workers/ThreadPoolBased/ThreadPoolWorkerFactory.cs
@@ -21,14 +21,14 @@ namespace Rebus.Workers.ThreadPoolBased
         readonly IPipelineInvoker _pipelineInvoker;
         readonly Options _options;
         readonly Func<RebusBus> _busGetter;
-        readonly IAsyncBackoffStrategy _backoffStrategy;
+        readonly IBackoffStrategy _backoffStrategy;
         readonly ParallelOperationsManager _parallelOperationsManager;
         readonly ILog _log;
 
         /// <summary>
         /// Creates the worker factory
         /// </summary>
-        public ThreadPoolWorkerFactory(ITransport transport, IRebusLoggerFactory rebusLoggerFactory, IPipelineInvoker pipelineInvoker, Options options, Func<RebusBus> busGetter, BusLifetimeEvents busLifetimeEvents, IAsyncBackoffStrategy backoffStrategy)
+        public ThreadPoolWorkerFactory(ITransport transport, IRebusLoggerFactory rebusLoggerFactory, IPipelineInvoker pipelineInvoker, Options options, Func<RebusBus> busGetter, BusLifetimeEvents busLifetimeEvents, IBackoffStrategy backoffStrategy)
         {
             if (busLifetimeEvents == null) throw new ArgumentNullException(nameof(busLifetimeEvents));
             _transport = transport ?? throw new ArgumentNullException(nameof(transport));


### PR DESCRIPTION
## Summary
As per https://github.com/rebus-org/Rebus/pull/728#issuecomment-416472836 this PR will make the backoff strategy support both sync and async awaiters, depending on the caller using this interface.

This allows ThreadPoolWorker to call the appropriate wait depending upon if its within a sync or async context.

## Changes
Renamed the interface to just be ``IBackoffStrategy`` and implemented sync and async variants of methods (Wait, WaitAsync, ...). I also made Reset just be void and non-async as its not supposed to be doing any blocking work anyway, for simplicity.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
