### PR TITLE
Include portable-pdbs in nuget package and enable SourceLink

### DIFF
--- a/Rebus/Rebus.csproj
+++ b/Rebus/Rebus.csproj
@@ -17,6 +17,17 @@
     <RepositoryUrl>https://github.com/rebus-org/Rebus</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PostBuildEvent></PostBuildEvent>
+    <Product>Rebus</Product>
+    <PackageId>Rebus</PackageId>
+    
+    <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+ 
+    <!-- Optional: Embed source files that are not tracked by the source control manager in the PDB -->
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+
+    <!-- Optional: Include the PDB in the built .nupkg -->
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -29,7 +40,7 @@
     <DocumentationFile>bin\Debug\Rebus.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>RELEASE</DefineConstants>
@@ -47,6 +58,12 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <DefineConstants>NETSTANDARD2_0</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net45|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
+  </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="System.Threading" Version="4.3.0" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />

--- a/Rebus/Rebus.csproj
+++ b/Rebus/Rebus.csproj
@@ -61,7 +61,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net45|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(EnableSourceLink)' != 'false'">
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,6 @@ before_build:
   - appveyor-retry dotnet restore -v Minimal
 
 build_script:
-  - dotnet build Rebus                  -c Release 
-  - dotnet build Rebus.Tests.Contracts  -c Release /p:WarningLevel=3
-  - dotnet build Rebus.Tests            -c Release /p:WarningLevel=3
+  - dotnet build Rebus                  -c Release /p:EnableSourceLink=false
+  - dotnet build Rebus.Tests.Contracts  -c Release /p:WarningLevel=3 /p:EnableSourceLink=false
+  - dotnet build Rebus.Tests            -c Release /p:WarningLevel=3 /p:EnableSourceLink=false


### PR DESCRIPTION
This uses the new [SourceLink v2](https://github.com/dotnet/sourcelink/) support available in Visual Studio 2017 15.3+. pdb files are included in the nuget package [as recommended by Microsoft](
https://github.com/aspnet/Universe/issues/131#issuecomment-363269268).

Fixes #730

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
