### PR TITLE
Make an actual use of the argument `incrementSlightlyOnEachInvocation`

### DIFF
--- a/Rebus/Time/RebusTimeMachine.cs
+++ b/Rebus/Time/RebusTimeMachine.cs
@@ -16,7 +16,11 @@ namespace Rebus.Time
             RebusTime.CurrentTimeFactory = () =>
             {
                 var timeToReturn = fakeTime;
-                fakeTime = fakeTime.AddTicks(1);
+                if (incrementSlightlyOnEachInvocation)
+                {
+                    fakeTime = fakeTime.AddTicks(1);
+                }
+
                 return timeToReturn;
             };
         }


### PR DESCRIPTION
In unit tests today one can call `RebusTimeMachine.FakeIt` to fake the current time in Rebus. The method creates a factory that increments the ticks every time `RebusTime.Now` is called. In some scenarios this is not wanted, so there exists the argument `incrementSlightlyOnEachInvocation` which can be set to `false`. Unfortunately, the argument is not used inside the created factory. See [issue](https://github.com/rebus-org/Rebus/issues/740) for more details.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
