### PR TITLE
Added count methods for InMemoryNetwork

### DIFF
--- a/Rebus/Transport/InMem/InMemNetwork.cs
+++ b/Rebus/Transport/InMem/InMemNetwork.cs
@@ -44,6 +44,20 @@ namespace Rebus.Transport.InMem
 
             _queues.Clear();
         }
+        
+        public int Count()
+        {
+            return _queues.Values.Sum(q => q.Count);
+        }
+
+        public int Count(string inputQueueName)
+        {
+            if (inputQueueName == null) throw new ArgumentNullException(nameof(inputQueueName));
+
+            var messageQueue = _queues.GetOrAdd(inputQueueName, address => new ConcurrentQueue<InMemTransportMessage>());
+
+            return messageQueue.Count;
+        }
 
         /// <summary>
         /// Delivers the specified <see cref="InMemTransportMessage"/> to the address specified by <paramref name="destinationAddress"/>.

--- a/Rebus/Transport/InMem/InMemNetwork.cs
+++ b/Rebus/Transport/InMem/InMemNetwork.cs
@@ -46,11 +46,17 @@ namespace Rebus.Transport.InMem
             _queues.Clear();
         }
         
+        /// <summary>
+        /// Get the total count of all queue messages
+        /// </summary>
         public int Count()
         {
             return _queues.Values.Sum(q => q.Count);
         }
 
+        /// <summary>
+        /// Get the current queue message count of the specified <paramref name="inputQueueName"/>
+        /// </summary>
         public int Count(string inputQueueName)
         {
             if (inputQueueName == null) throw new ArgumentNullException(nameof(inputQueueName));

--- a/Rebus/Transport/InMem/InMemNetwork.cs
+++ b/Rebus/Transport/InMem/InMemNetwork.cs
@@ -1,9 +1,10 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
+using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using Rebus.Extensions;
 using Rebus.Messages;
+using Rebus.Transport.InMem;
 
 namespace Rebus.Transport.InMem
 {


### PR DESCRIPTION
We have a few small microservices that does not need to be durable. So we just use In Memory transport. However, we do want to query the status of the services and an insight into queue count is helpful.
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
