### PR TITLE
Backoff prevents shutdown

### DIFF
--- a/Rebus.Tests/Backoff/TestBackoffBehaviorWhenBusy.cs
+++ b/Rebus.Tests/Backoff/TestBackoffBehaviorWhenBusy.cs
@@ -122,10 +122,10 @@ namespace Rebus.Tests.Backoff
                 BackoffStrategy.Reset();
             }
 
-            public void WaitNoMessage()
+            public void WaitNoMessage(CancellationToken token)
             {
                 _waitNoMessageTimes.Enqueue(DateTime.UtcNow);
-                BackoffStrategy.WaitNoMessage();
+                BackoffStrategy.WaitNoMessage(token);
             }
 
 	        public Task WaitNoMessageAsync(CancellationToken token)
@@ -146,9 +146,9 @@ namespace Rebus.Tests.Backoff
 		        return BackoffStrategy.WaitAsync(token);
 	        }
 
-			public void WaitError()
+			public void WaitError(CancellationToken token)
             {
-                BackoffStrategy.WaitError();
+                BackoffStrategy.WaitError(token);
             }
 
 	        public Task WaitErrorAsync(CancellationToken token)

--- a/Rebus.Tests/Backoff/TestBackoffRespectsCancellation.cs
+++ b/Rebus.Tests/Backoff/TestBackoffRespectsCancellation.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Rebus.Activation;
+using Rebus.Backoff;
+using Rebus.Bus;
+using Rebus.Config;
+using Rebus.Logging;
+using Rebus.Tests.Contracts;
+using Rebus.Tests.Contracts.Extensions;
+using Rebus.Transport.InMem;
+using Rebus.Workers.ThreadPoolBased;
+
+namespace Rebus.Tests.Backoff
+{
+    [TestFixture]
+    public class TestBackoffRespectsCancellation : FixtureBase
+    {
+        private IBus _bus;
+        private BackoffSnitch _snitch;
+
+        protected override void SetUp()
+        {
+            var activator = Using(new BuiltinHandlerActivator());
+
+            _snitch = new BackoffSnitch();
+
+            _bus = Configure.With(activator)
+                .Logging(l => l.Console(LogLevel.Info))
+                .Transport(t => t.UseInMemoryTransport(new InMemNetwork(), "cancellation-test"))
+                .Options(o =>
+                {
+                    o.SetMaxParallelism(1);
+                    o.SetNumberOfWorkers(1);
+                    o.SetBackoffTimes(TimeSpan.FromDays(1));
+                    o.SetWorkerShutdownTimeout(TimeSpan.FromMinutes(1));
+
+                    // install the snitch
+                    o.Decorate<IBackoffStrategy>(c =>
+                    {
+                        var backoffStrategy = c.Get<IBackoffStrategy>();
+                        _snitch.BackoffStrategy = backoffStrategy;
+                        return _snitch;
+                    });
+                })
+                .Start();
+        }
+
+        [TestCase]
+        public void BackoffRespectsCancellation()
+        {
+            // Wait until the backoff strategy has entered an wait cycle 
+            _snitch.WaitNoMessageEntered.WaitOrDie(TimeSpan.FromSeconds(10),
+                "Backoff strategy did not enter an wait cycle within the expected timeframe!");
+
+            var shutdownSignal = new ManualResetEvent(false);
+            var thread = new Thread(() =>
+            {
+                _bus.Dispose();
+                shutdownSignal.Set();
+            });
+
+            thread.Start();
+            shutdownSignal.WaitOrDie(TimeSpan.FromSeconds(1),
+                "Rebus did not shut down within the expected timeframe because the worker " +
+                "did not return from its backoff wait cycle!");
+        }
+
+        private class BackoffSnitch : IBackoffStrategy
+        {
+            public IBackoffStrategy BackoffStrategy { get; set; }
+
+            public ManualResetEvent WaitNoMessageEntered { get; }
+                = new ManualResetEvent(false);
+
+            public void Reset()
+            {
+                BackoffStrategy.Reset();
+            }
+
+            public void WaitNoMessage(CancellationToken token)
+            {
+                BackoffStrategy.WaitNoMessage(token);
+            }
+
+            public async Task WaitNoMessageAsync(CancellationToken token)
+            {
+                WaitNoMessageEntered.Set();
+                await BackoffStrategy.WaitNoMessageAsync(token);
+            }
+
+            public void Wait(CancellationToken token)
+            {
+                BackoffStrategy.Wait(token);
+            }
+
+            public Task WaitAsync(CancellationToken token)
+            {
+                return BackoffStrategy.WaitAsync(token);
+            }
+
+            public void WaitError(CancellationToken token)
+            {
+                BackoffStrategy.WaitError(token);
+            }
+
+            public Task WaitErrorAsync(CancellationToken token)
+            {
+                return BackoffStrategy.WaitErrorAsync(token);
+            }
+        }
+    }
+}

--- a/Rebus.Tests/Backoff/TestCustomizedBackoff.cs
+++ b/Rebus.Tests/Backoff/TestCustomizedBackoff.cs
@@ -17,7 +17,7 @@ namespace Rebus.Tests.Backoff
     public class TestCustomizedBackoff : FixtureBase
     {
         [Test]
-        public void RunIdleForSomeTIme()
+        public void RunIdleForSomeTime()
         {
             var receiveCalls = RunTest(false);
             var receiveCallsWithCustomizedBackoff = RunTest(true);

--- a/Rebus.Tests/Workers/TestDefaultBackoffStrategy.cs
+++ b/Rebus.Tests/Workers/TestDefaultBackoffStrategy.cs
@@ -25,9 +25,9 @@ namespace Rebus.Tests.Workers
 		    backoffStrategy.Wait(CancellationToken.None);
 		    stopwatch.Stop();
 
-			// Assert
-			Assert.GreaterOrEqual(stopwatch.Elapsed, TimeSpan.FromMilliseconds(500));
-	    }
+            // Assert
+            Assert.That(stopwatch.Elapsed, Is.GreaterThan(TimeSpan.FromMilliseconds(450)).And.LessThan(TimeSpan.FromMilliseconds(550)));
+        }
 
 	    [Test]
 	    public async Task WaitAsyncDoesPause()

--- a/Rebus/Workers/ThreadPoolBased/IBackoffStrategy.cs
+++ b/Rebus/Workers/ThreadPoolBased/IBackoffStrategy.cs
@@ -20,14 +20,15 @@ namespace Rebus.Workers.ThreadPoolBased
         /// Executes the next wait operation by blocking the thread, possibly advancing the wait cursor to a different wait time for the next time.
         /// This function is called each time a worker thread cannot continue because no more parallel operations are allowed to happen.
         /// </summary>
-        /// <param name="cancellationToken"></param>
-        Task WaitAsync(CancellationToken cancellationToken);
+        /// <param name="token"></param>
+        Task WaitAsync(CancellationToken token);
 
-		/// <summary>
-		/// Executes the next wait operation by blocking the thread, possibly advancing the wait cursor to a different wait time for the next time.
-		/// This function is called each time no message was received.
-		/// </summary>
-		void WaitNoMessage();
+        /// <summary>
+        /// Executes the next wait operation by blocking the thread, possibly advancing the wait cursor to a different wait time for the next time.
+        /// This function is called each time no message was received.
+        /// </summary>
+        /// <param name="token"></param>
+        void WaitNoMessage(CancellationToken token);
 
         /// <summary>
         /// Executes the next wait operation by blocking the thread, possibly advancing the wait cursor to a different wait time for the next time.
@@ -36,10 +37,11 @@ namespace Rebus.Workers.ThreadPoolBased
         /// <param name="token"></param>
         Task WaitNoMessageAsync(CancellationToken token);
 
-		/// <summary>
-		/// Blocks the thread for a (most likely longer) while, when an error has occurred
-		/// </summary>
-		void WaitError();
+        /// <summary>
+        /// Blocks the thread for a (most likely longer) while, when an error has occurred
+        /// </summary>
+        /// <param name="token"></param>
+        void WaitError(CancellationToken token);
 
         /// <summary>
         /// Blocks the thread for a (most likely longer) while, when an error has occurred

--- a/Rebus/Workers/ThreadPoolBased/ThreadPoolWorker.cs
+++ b/Rebus/Workers/ThreadPoolBased/ThreadPoolWorker.cs
@@ -65,7 +65,7 @@ namespace Rebus.Workers.ThreadPoolBased
                 {
                     _log.Error(exception, "Unhandled exception in worker {workerName} when try-receiving", Name);
 
-                    _backoffStrategy.WaitError();
+                    _backoffStrategy.WaitError(token);
                 }
             }
 


### PR DESCRIPTION
@mookid8000 Hey mogens,

i noticed that the default backoff strategy does not respect the given cancellation token.

If you have an usecase where rebus should poll in a very rare interval, let's assume once a day for example, shutting down rebus takes at least the worker shutdown timeout, because the worker 'hangs' within the backoff wait cycle. Once the worker has reached the shutdown timeout, the rebus shutdown process continues as expected.

If the backoff strategy would respect the cancellation token, the backoff wait cycle would immediately be over and the shutdown could continue.

what do you think about this?

sincerely,

nolde

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
