### PR TITLE
Identifying the bus which is about to change the number of workers

### DIFF
--- a/Rebus/Bus/RebusBus.cs
+++ b/Rebus/Bus/RebusBus.cs
@@ -513,13 +513,13 @@ namespace Rebus.Bus
 
             if (desiredNumberOfWorkers > _options.MaxParallelism)
             {
-                _log.Warn("Attempted to set number of workers to {numberOfWorkers}, but the max allowed parallelism is {maxParallelism}",
-                    desiredNumberOfWorkers, _options.MaxParallelism);
+                _log.Warn("Bus {busName} attempted to set number of workers to {numberOfWorkers}, but the max allowed parallelism is {maxParallelism}",
+                    _busName, desiredNumberOfWorkers, _options.MaxParallelism);
 
                 desiredNumberOfWorkers = _options.MaxParallelism;
             }
 
-            _log.Info("Setting number of workers to {numberOfWorkers}", desiredNumberOfWorkers);
+            _log.Info("Bus {busName} setting number of workers to {numberOfWorkers}", _busName, desiredNumberOfWorkers);
             while (desiredNumberOfWorkers > GetNumberOfWorkers())
             {
                 AddWorker();


### PR DESCRIPTION
@mookid8000 Hey mogens,

in analogy to the log message when a bus is getting started
```
[Information] Bus "CRM" started
[Information] Bus "ERP" started
[Information] Bus "Whatever" started
```

i changed the log message when a bus is about to change the number of workers from
```
[Information] Setting number of workers to 1
[Information] Setting number of workers to 5
[Information] Setting number of workers to 2
```

to this kind, where the bus name is included
```
[Information] Bus "CRM" setting number of workers to 1
[Information] Bus "ERP" setting number of workers to 5
[Information] Bus "Whatever" setting number of workers to 2
```

Especially if you're using auto scaling feature, this should improve the recognizability from the log.

Sincerely,

nolde

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
