### PR TITLE
Make logging more symmetrical when sending and receiving messages

### DIFF
--- a/Rebus/Bus/MessageExtensions.cs
+++ b/Rebus/Bus/MessageExtensions.cs
@@ -150,7 +150,7 @@ namespace Rebus.Bus
 
         static string GetMessageLabel(string id, string type)
         {
-            return $"{type}/{id}";
+            return $"{type}, {id}";
         }
     }
 }

--- a/Rebus/Bus/MessageExtensions.cs
+++ b/Rebus/Bus/MessageExtensions.cs
@@ -62,6 +62,24 @@ namespace Rebus.Bus
         }
 
         /// <summary>
+        /// Gets the sender address from the message.
+        /// </summary>
+        public static string GetSenderAddress(this Message message)
+        {
+            return message.Headers.GetValueOrNull(Headers.SenderAddress)
+                   ?? "<unknown>";
+        }
+
+        /// <summary>
+        /// Gets the sender address from the message.
+        /// </summary>
+        public static string GetSenderAddress(this TransportMessage message)
+        {
+            return message.Headers.GetValueOrNull(Headers.SenderAddress)
+                   ?? "<unknown>";
+        }
+
+        /// <summary>
         /// Gets the message type from the message
         /// </summary>
         public static string GetMessageType(this Message message)
@@ -77,6 +95,7 @@ namespace Rebus.Bus
         public static string GetMessageType(this TransportMessage message)
         {
             return message.Headers.GetValueOrNull(Headers.Type)
+                   ?? GetTypeNameFromBodyObjectOrNull(message.Body)
                    ?? "<unknown>";
         }
 
@@ -101,7 +120,9 @@ namespace Rebus.Bus
         /// </summary>
         public static string GetMessageLabel(this Message message)
         {
-            return GetMessageLabel(message.Headers);
+            var messageId = GetMessageId(message);
+            var messageType = GetMessageType(message);
+            return GetMessageLabel(messageId, messageType);
         }
 
         /// <summary>
@@ -109,7 +130,9 @@ namespace Rebus.Bus
         /// </summary>
         public static string GetMessageLabel(this TransportMessage message)
         {
-            return GetMessageLabel(message.Headers);
+            var messageId = GetMessageId(message);
+            var messageType = GetMessageType(message);
+            return GetMessageLabel(messageId, messageType);
         }
 
         /// <summary>
@@ -120,30 +143,14 @@ namespace Rebus.Bus
             return new TransportMessage(message.Headers.Clone(), message.Body);
         }
 
-        static string GetMessageLabel(Dictionary<string, string> headers)
-        {
-            var id = headers.GetValueOrNull(Headers.MessageId) ?? "<unknown>";
-
-            if (headers.TryGetValue(Headers.Type, out var type))
-            {
-                var dotnetType = Type.GetType(type);
-
-                if (dotnetType != null)
-                {
-                    type = dotnetType.Name;
-                }
-            }
-            else
-            {
-                type = "<unknown>";
-            }
-
-            return $"{type}/{id}";
-        }
-
         static string GetTypeNameFromBodyObjectOrNull(object body)
         {
             return body?.GetType().GetSimpleAssemblyQualifiedName();
+        }
+
+        static string GetMessageLabel(string id, string type)
+        {
+            return $"{type}/{id}";
         }
     }
 }

--- a/Rebus/Pipeline/Send/SendOutgoingMessageStep.cs
+++ b/Rebus/Pipeline/Send/SendOutgoingMessageStep.cs
@@ -42,7 +42,8 @@ namespace Rebus.Pipeline.Send
 
             var hasOneOrMoreDestinations = destinationAddressesList.Any();
 
-            _log.Debug("Sending {messageBody} -> {queueNames}",
+            _log.Debug("Bus {busName} sending {messageBody} -> {queueNames}",
+                _transport.Address,
                 logicalMessage.Body ?? "<empty message>",
                 hasOneOrMoreDestinations ? string.Join(";", destinationAddressesList) : "<no destinations>");
 

--- a/Rebus/Pipeline/Send/SendOutgoingMessageStep.cs
+++ b/Rebus/Pipeline/Send/SendOutgoingMessageStep.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Rebus.Bus;
 using Rebus.Logging;
 using Rebus.Messages;
 using Rebus.Transport;
@@ -42,10 +43,12 @@ namespace Rebus.Pipeline.Send
 
             var hasOneOrMoreDestinations = destinationAddressesList.Any();
 
-            _log.Debug("Bus {busName} sending {messageBody} -> {queueNames}",
-                _transport.Address,
-                logicalMessage.Body ?? "<empty message>",
-                hasOneOrMoreDestinations ? string.Join(";", destinationAddressesList) : "<no destinations>");
+            _log.Debug("Sending {messageLabel} from {senderAddress} -> {queueNames}",
+                logicalMessage.GetMessageLabel(),
+                logicalMessage.GetSenderAddress(),
+                hasOneOrMoreDestinations ?
+                    string.Join(";", destinationAddressesList)
+                    : "<no destinations>");
 
             await Send(destinationAddressesList, transportMessage, currentTransactionContext);
 


### PR DESCRIPTION
@mookid8000 Hey mogens,

I've made logging more symmetrical when sending and receiving messages by using the same label.
This will change the original message from:
```
[DBG] Sending Testing.Library.CommandA -> "CRM"
[DBG] Sending Testing.Library.CommandB -> "ERP"
```

to this kind:
```
[DBG] Sending Testing.Library.CommandA, Testing, <ID> from "Whatever" -> "CRM"
[DBG] Sending Testing.Library.CommandB, Testing, <ID> from "Whatever" -> "ERP"
```

to better meet the other side:
```
[DBG] Dispatching Testing.Library.CommandA, Testing, <ID> to 1 handlers took 563 ms
[DBG] Dispatching Testing.Library.CommandA, Testing, <ID> to 1 handlers took 563 ms
```

This change brings the outgoing message id into the (debug) log, which is currently missing.
Especially if you're using Request/Reply using Rebus.Async, this helps to track the flow.

Sincerely,
nolde

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
