### PR TITLE
Update interfaces to accept IDictionary<string,string> for optionalHeaders

### DIFF
--- a/Rebus.Tests.Contracts/Activation/ContainerTests.cs
+++ b/Rebus.Tests.Contracts/Activation/ContainerTests.cs
@@ -221,15 +221,15 @@ has failed too many times)
 
             public void Dispose() => _bus.Dispose();
 
-            public Task SendLocal(object commandMessage, Dictionary<string, string> optionalHeaders = null) => _bus.SendLocal(commandMessage, optionalHeaders);
+            public Task SendLocal(object commandMessage, IDictionary<string, string> optionalHeaders = null) => _bus.SendLocal(commandMessage, optionalHeaders);
 
-            public Task Send(object commandMessage, Dictionary<string, string> optionalHeaders = null) => _bus.SendLocal(commandMessage, optionalHeaders);
+            public Task Send(object commandMessage, IDictionary<string, string> optionalHeaders = null) => _bus.SendLocal(commandMessage, optionalHeaders);
 
-            public Task Reply(object replyMessage, Dictionary<string, string> optionalHeaders = null) => _bus.Reply(replyMessage, optionalHeaders);
+            public Task Reply(object replyMessage, IDictionary<string, string> optionalHeaders = null) => _bus.Reply(replyMessage, optionalHeaders);
 
-            public Task Defer(TimeSpan delay, object message, Dictionary<string, string> optionalHeaders = null) => _bus.Defer(delay, message, optionalHeaders);
+            public Task Defer(TimeSpan delay, object message, IDictionary<string, string> optionalHeaders = null) => _bus.Defer(delay, message, optionalHeaders);
 
-            public Task DeferLocal(TimeSpan delay, object message, Dictionary<string, string> optionalHeaders = null) => _bus.DeferLocal(delay, message, optionalHeaders);
+            public Task DeferLocal(TimeSpan delay, object message, IDictionary<string, string> optionalHeaders = null) => _bus.DeferLocal(delay, message, optionalHeaders);
 
             public IAdvancedApi Advanced => _bus.Advanced;
 
@@ -241,7 +241,7 @@ has failed too many times)
 
             public Task Unsubscribe(Type eventType) => _bus.Unsubscribe(eventType);
 
-            public Task Publish(object eventMessage, Dictionary<string, string> optionalHeaders = null) => _bus.Publish(eventMessage, optionalHeaders);
+            public Task Publish(object eventMessage, IDictionary<string, string> optionalHeaders = null) => _bus.Publish(eventMessage, optionalHeaders);
         }
 
         [Test]
@@ -275,32 +275,32 @@ has failed too many times)
                 Disposed = true;
             }
 
-            public Task SendLocal(object commandMessage, Dictionary<string, string> optionalHeaders = null)
+            public Task SendLocal(object commandMessage, IDictionary<string, string> optionalHeaders = null)
             {
                 throw new NotImplementedException();
             }
 
-            public Task Send(object commandMessage, Dictionary<string, string> optionalHeaders = null)
+            public Task Send(object commandMessage, IDictionary<string, string> optionalHeaders = null)
             {
                 throw new NotImplementedException();
             }
 
-            public Task Reply(object replyMessage, Dictionary<string, string> optionalHeaders = null)
+            public Task Reply(object replyMessage, IDictionary<string, string> optionalHeaders = null)
             {
                 throw new NotImplementedException();
             }
 
-            public Task Publish(string topic, object eventMessage, Dictionary<string, string> optionalHeaders = null)
+            public Task Publish(string topic, object eventMessage, IDictionary<string, string> optionalHeaders = null)
             {
                 throw new NotImplementedException();
             }
 
-            public Task Defer(TimeSpan delay, object message, Dictionary<string, string> optionalHeaders = null)
+            public Task Defer(TimeSpan delay, object message, IDictionary<string, string> optionalHeaders = null)
             {
                 throw new NotImplementedException();
             }
 
-            public Task DeferLocal(TimeSpan delay, object message, Dictionary<string, string> optionalHeaders = null)
+            public Task DeferLocal(TimeSpan delay, object message, IDictionary<string, string> optionalHeaders = null)
             {
                 throw new NotImplementedException();
             }
@@ -315,7 +315,7 @@ has failed too many times)
                 throw new NotImplementedException();
             }
 
-            public Task Route(string destinationAddress, object explicitlyRoutedMessage, Dictionary<string, string> optionalHeaders = null)
+            public Task Route(string destinationAddress, object explicitlyRoutedMessage, IDictionary<string, string> optionalHeaders = null)
             {
                 throw new NotImplementedException();
             }
@@ -342,7 +342,7 @@ has failed too many times)
                 throw new NotImplementedException();
             }
 
-            public Task Publish(object eventMessage, Dictionary<string, string> optionalHeaders = null)
+            public Task Publish(object eventMessage, IDictionary<string, string> optionalHeaders = null)
             {
                 throw new NotImplementedException();
             }

--- a/Rebus/Bus/Advanced/IRoutingApi.cs
+++ b/Rebus/Bus/Advanced/IRoutingApi.cs
@@ -13,17 +13,17 @@ namespace Rebus.Bus.Advanced
         /// <summary>
         /// Explicitly routes the <paramref name="explicitlyRoutedMessage"/> to the destination specified by <paramref name="destinationAddress"/>
         /// </summary>
-        Task Send(string destinationAddress, object explicitlyRoutedMessage, Dictionary<string, string> optionalHeaders = null);
+        Task Send(string destinationAddress, object explicitlyRoutedMessage, IDictionary<string, string> optionalHeaders = null);
 
         /// <summary>
         /// Sends the message as a routing slip that will visit the destinations specified by the given <see cref="Itinerary"/>
         /// </summary>
-        Task SendRoutingSlip(Itinerary itinerary, object message, Dictionary<string, string> optionalHeaders = null);
+        Task SendRoutingSlip(Itinerary itinerary, object message, IDictionary<string, string> optionalHeaders = null);
 
         /// <summary>
         /// Explicitly routes the <paramref name="explicitlyRoutedMessage"/> to the destination specified by <paramref name="destinationAddress"/>,
         /// delaying delivery approximately by the time specified by <paramref name="delay"/>.
         /// </summary>
-        Task Defer(string destinationAddress, TimeSpan delay, object explicitlyRoutedMessage, Dictionary<string, string> optionalHeaders = null);
+        Task Defer(string destinationAddress, TimeSpan delay, object explicitlyRoutedMessage, IDictionary<string, string> optionalHeaders = null);
     }
 }

--- a/Rebus/Bus/Advanced/ISyncBus.cs
+++ b/Rebus/Bus/Advanced/ISyncBus.cs
@@ -16,32 +16,32 @@ namespace Rebus.Bus.Advanced
         /// <summary>
         /// Sends the specified message to our own input queue address
         /// </summary>
-        void SendLocal(object commandMessage, Dictionary<string, string> optionalHeaders = null);
+        void SendLocal(object commandMessage, IDictionary<string, string> optionalHeaders = null);
 
         /// <summary>
         /// Sends the specified message to a destination that is determined by calling <see cref="IRouter.GetDestinationAddress"/>
         /// </summary>
-        void Send(object commandMessage, Dictionary<string, string> optionalHeaders = null);
+        void Send(object commandMessage, IDictionary<string, string> optionalHeaders = null);
 
         /// <summary>
         /// Sends the specified reply message to a destination that is determined by looking up the <see cref="Headers.ReturnAddress"/> header of the message currently being handled.
         /// This method can only be called from within a message handler.
         /// </summary>
-        void Reply(object replyMessage, Dictionary<string, string> optionalHeaders = null);
+        void Reply(object replyMessage, IDictionary<string, string> optionalHeaders = null);
 
         /// <summary>
         /// Defers into the future the specified message, optionally specifying some headers to attach to the message. Unless the <see cref="Headers.DeferredRecipient"/> is specified
         /// in a header, the endpoint mapping corresponding to the sent message will be set as the return address, which will cause the message to be delivered to that address when the <paramref name="delay"/>
         /// has elapsed.
         /// </summary>
-        void Defer(TimeSpan delay, object message, Dictionary<string, string> optionalHeaders = null);
+        void Defer(TimeSpan delay, object message, IDictionary<string, string> optionalHeaders = null);
 
         /// <summary>
         /// Defers into the future the specified message, optionally specifying some headers to attach to the message. Unless the <see cref="Headers.DeferredRecipient"/> is specified
         /// in a header, the bus instance's own input address will be set as the return address, which will cause the message to be delivered to that address when the <paramref name="delay"/>
         /// has elapsed.
         /// </summary>
-        void DeferLocal(TimeSpan delay, object message, Dictionary<string, string> optionalHeaders = null);
+        void DeferLocal(TimeSpan delay, object message, IDictionary<string, string> optionalHeaders = null);
 
         /// <summary>
         /// Subscribes to the topic defined by the assembly-qualified name of <typeparamref name="TEvent"/>. 
@@ -96,6 +96,6 @@ namespace Rebus.Bus.Advanced
         /// </code>
         /// in the configuration
         /// </summary>
-        void Publish(object eventMessage, Dictionary<string, string> optionalHeaders = null);
+        void Publish(object eventMessage, IDictionary<string, string> optionalHeaders = null);
     }
 }

--- a/Rebus/Bus/Advanced/ITopicsApi.cs
+++ b/Rebus/Bus/Advanced/ITopicsApi.cs
@@ -15,7 +15,7 @@ namespace Rebus.Bus.Advanced
         /// Publishes the specified message to the specified topic. Default behavior is to look up the addresses of those who subscribed to the given topic
         /// by calling <see cref="ISubscriptionStorage.GetSubscriberAddresses"/> but the transport may override this behavior if it has special capabilities.
         /// </summary>
-        Task Publish(string topic, object eventMessage, Dictionary<string, string> optionalHeaders = null);
+        Task Publish(string topic, object eventMessage, IDictionary<string, string> optionalHeaders = null);
 
         /// <summary>
         /// Subscribes the current endpoint to the given topic. If the <see cref="ISubscriptionStorage"/> is centralized (determined by checking <see cref="ISubscriptionStorage.IsCentralized"/>),

--- a/Rebus/Bus/AdvancedRebusBus.cs
+++ b/Rebus/Bus/AdvancedRebusBus.cs
@@ -113,27 +113,27 @@ namespace Rebus.Bus
                 _rebusBus = rebusBus;
             }
 
-            public void SendLocal(object commandMessage, Dictionary<string, string> optionalHeaders = null)
+            public void SendLocal(object commandMessage, IDictionary<string, string> optionalHeaders = null)
             {
                 AsyncHelpers.RunSync(() => _rebusBus.SendLocal(commandMessage, optionalHeaders));
             }
 
-            public void Send(object commandMessage, Dictionary<string, string> optionalHeaders = null)
+            public void Send(object commandMessage, IDictionary<string, string> optionalHeaders = null)
             {
                 AsyncHelpers.RunSync(() => _rebusBus.Send(commandMessage, optionalHeaders));
             }
 
-            public void Reply(object replyMessage, Dictionary<string, string> optionalHeaders = null)
+            public void Reply(object replyMessage, IDictionary<string, string> optionalHeaders = null)
             {
                 AsyncHelpers.RunSync(() => _rebusBus.Reply(replyMessage, optionalHeaders));
             }
 
-            public void Defer(TimeSpan delay, object message, Dictionary<string, string> optionalHeaders = null)
+            public void Defer(TimeSpan delay, object message, IDictionary<string, string> optionalHeaders = null)
             {
                 AsyncHelpers.RunSync(() => _rebusBus.Defer(delay, message, optionalHeaders));
             }
 
-            public void DeferLocal(TimeSpan delay, object message, Dictionary<string, string> optionalHeaders = null)
+            public void DeferLocal(TimeSpan delay, object message, IDictionary<string, string> optionalHeaders = null)
             {
                 AsyncHelpers.RunSync(() => _rebusBus.DeferLocal(delay, message, optionalHeaders));
             }
@@ -158,7 +158,7 @@ namespace Rebus.Bus
                 AsyncHelpers.RunSync(() => _rebusBus.Unsubscribe(eventType));
             }
 
-            public void Publish(object eventMessage, Dictionary<string, string> optionalHeaders = null)
+            public void Publish(object eventMessage, IDictionary<string, string> optionalHeaders = null)
             {
                 AsyncHelpers.RunSync(() => _rebusBus.Publish(eventMessage, optionalHeaders));
             }
@@ -175,14 +175,14 @@ namespace Rebus.Bus
                 _rebusTime = rebusTime;
             }
 
-            public Task Send(string destinationAddress, object explicitlyRoutedMessage, Dictionary<string, string> optionalHeaders = null)
+            public Task Send(string destinationAddress, object explicitlyRoutedMessage, IDictionary<string, string> optionalHeaders = null)
             {
                 var logicalMessage = CreateMessage(explicitlyRoutedMessage, Operation.Send, optionalHeaders);
 
                 return _rebusBus.InnerSend(new[] { destinationAddress }, logicalMessage);
             }
 
-            public Task Defer(string destinationAddress, TimeSpan delay, object explicitlyRoutedMessage, Dictionary<string, string> optionalHeaders = null)
+            public Task Defer(string destinationAddress, TimeSpan delay, object explicitlyRoutedMessage, IDictionary<string, string> optionalHeaders = null)
             {
                 var logicalMessage = CreateMessage(explicitlyRoutedMessage, Operation.Defer, optionalHeaders);
 
@@ -193,7 +193,7 @@ namespace Rebus.Bus
                 return _rebusBus.InnerSend(new[] { timeoutManagerAddress }, logicalMessage);
             }
 
-            public Task SendRoutingSlip(Itinerary itinerary, object message, Dictionary<string, string> optionalHeaders = null)
+            public Task SendRoutingSlip(Itinerary itinerary, object message, IDictionary<string, string> optionalHeaders = null)
             {
                 var logicalMessage = CreateMessage(message, Operation.Send, optionalHeaders);
                 var destinationAddresses = itinerary.GetDestinationAddresses();
@@ -256,7 +256,7 @@ namespace Rebus.Bus
                 _rebusBus = rebusBus;
             }
 
-            public Task Publish(string topic, object eventMessage, Dictionary<string, string> optionalHeaders = null)
+            public Task Publish(string topic, object eventMessage, IDictionary<string, string> optionalHeaders = null)
             {
                 return _rebusBus.InnerPublish(topic, eventMessage, optionalHeaders);
             }

--- a/Rebus/Bus/IBus.cs
+++ b/Rebus/Bus/IBus.cs
@@ -14,31 +14,31 @@ namespace Rebus.Bus
         /// <summary>
         /// Sends the specified command message to this instance's own input queue, optionally specifying some headers to attach to the message
         /// </summary>
-        Task SendLocal(object commandMessage, Dictionary<string, string> optionalHeaders = null);
+        Task SendLocal(object commandMessage, IDictionary<string, string> optionalHeaders = null);
 
         /// <summary>
         /// Sends the specified command message to the address mapped as the owner of the message type, optionally specifying some headers to attach to the message
         /// </summary>
-        Task Send(object commandMessage, Dictionary<string, string> optionalHeaders = null);
+        Task Send(object commandMessage, IDictionary<string, string> optionalHeaders = null);
 
         /// <summary>
         /// Defers the message delivery into the future, optionally specifying some headers to attach to the message. Unless the <see cref="Headers.DeferredRecipient"/> is specified
         /// in a header, the bus instance's own input queue address will be set as the return address, which will cause the message to be delivered to that address when the <paramref name="delay"/>
         /// has elapsed.
         /// </summary>
-        Task DeferLocal(TimeSpan delay, object message, Dictionary<string, string> optionalHeaders = null);
+        Task DeferLocal(TimeSpan delay, object message, IDictionary<string, string> optionalHeaders = null);
 
         /// <summary>
         /// Defers the message delivery into the future, optionally specifying some headers to attach to the message. Unless the <see cref="Headers.DeferredRecipient"/> is specified
         /// in a header, the endpoint mapping corresponding to the sent message will be set as the return address, which will cause the message to be delivered to that address when the <paramref name="delay"/>
         /// has elapsed.
         /// </summary>
-        Task Defer(TimeSpan delay, object message, Dictionary<string, string> optionalHeaders = null);
+        Task Defer(TimeSpan delay, object message, IDictionary<string, string> optionalHeaders = null);
 
         /// <summary>
         /// Replies back to the endpoint specified as return address on the message currently being handled. Throws an <see cref="InvalidOperationException"/> if called outside of a proper message context.
         /// </summary>
-        Task Reply(object replyMessage, Dictionary<string, string> optionalHeaders = null);
+        Task Reply(object replyMessage, IDictionary<string, string> optionalHeaders = null);
 
         /// <summary>
         /// Subscribes to the topic defined by the assembly-qualified name of <typeparamref name="TEvent"/>. 
@@ -93,7 +93,7 @@ namespace Rebus.Bus
         /// </code>
         /// in the configuration
         /// </summary>
-        Task Publish(object eventMessage, Dictionary<string, string> optionalHeaders = null);
+        Task Publish(object eventMessage, IDictionary<string, string> optionalHeaders = null);
 
         /// <summary>
         /// Gets the API for advanced features of the bus

--- a/Rebus/Config/OneWayClientBusDecorator.cs
+++ b/Rebus/Config/OneWayClientBusDecorator.cs
@@ -24,27 +24,27 @@ namespace Rebus.Config
             _innerBus.Dispose();
         }
 
-        public Task SendLocal(object commandMessage, Dictionary<string, string> optionalHeaders = null)
+        public Task SendLocal(object commandMessage, IDictionary<string, string> optionalHeaders = null)
         {
             return _innerBus.SendLocal(commandMessage, optionalHeaders);
         }
 
-        public Task Send(object commandMessage, Dictionary<string, string> optionalHeaders = null)
+        public Task Send(object commandMessage, IDictionary<string, string> optionalHeaders = null)
         {
             return _innerBus.Send(commandMessage, optionalHeaders);
         }
 
-        public Task Reply(object replyMessage, Dictionary<string, string> optionalHeaders = null)
+        public Task Reply(object replyMessage, IDictionary<string, string> optionalHeaders = null)
         {
             return _innerBus.Reply(replyMessage, optionalHeaders);
         }
 
-        public Task Defer(TimeSpan delay, object message, Dictionary<string, string> optionalHeaders = null)
+        public Task Defer(TimeSpan delay, object message, IDictionary<string, string> optionalHeaders = null)
         {
             return _innerBus.Defer(delay, message, optionalHeaders);
         }
 
-        public Task DeferLocal(TimeSpan delay, object message, Dictionary<string, string> optionalHeaders = null)
+        public Task DeferLocal(TimeSpan delay, object message, IDictionary<string, string> optionalHeaders = null)
         {
             return _innerBus.DeferLocal(delay, message, optionalHeaders);
         }
@@ -71,7 +71,7 @@ namespace Rebus.Config
             return _innerBus.Unsubscribe(eventType);
         }
 
-        public Task Publish(object eventMessage, Dictionary<string, string> optionalHeaders = null)
+        public Task Publish(object eventMessage, IDictionary<string, string> optionalHeaders = null)
         {
             return _innerBus.Publish(eventMessage, optionalHeaders);
         }


### PR DESCRIPTION
Fixes:  #816

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
