### PR TITLE
Fix typo

### DIFF
--- a/Rebus/Config/OneWayClientBackdoor.cs
+++ b/Rebus/Config/OneWayClientBackdoor.cs
@@ -29,7 +29,7 @@ namespace Rebus.Config
 
                 if (transport.Address != null)
                 {
-                    throw new InvalidOperationException($"Cannot configure thus but to be a one-way client, because the transport is configured with '{transport.Address}' as its input queue. One-way clients must have a NULL input queue, otherwise the transport could be fooled into believing it was supposed to receive messages");
+                    throw new InvalidOperationException($"Cannot configure this bus to be a one-way client, because the transport is configured with '{transport.Address}' as its input queue. One-way clients must have a NULL input queue, otherwise the transport could be fooled into believing it was supposed to receive messages");
                 }
 
                 var options = c.Get<Options>();


### PR DESCRIPTION
Typo I noticed in the error message

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
