### PR TITLE
Handle Communication without Message Sharing

### DIFF
--- a/Rebus.Tests/Assumptions/TestSpecificSerializationExample.cs
+++ b/Rebus.Tests/Assumptions/TestSpecificSerializationExample.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 using Rebus.Activation;
 using Rebus.Config;
 using Rebus.Messages;
+using Rebus.Messages.MessageType;
 using Rebus.Serialization.Json;
 using Rebus.Tests.Contracts;
 using Rebus.Tests.Contracts.Extensions;
@@ -23,7 +24,7 @@ namespace Rebus.Tests.Assumptions
 
         protected override void SetUp()
         {
-            _serializer = new JsonSerializer();
+            _serializer = new JsonSerializer(new DefaultMessageTypeMapper());
         }
 
         [Test]

--- a/Rebus.Tests/MessageType/TestDefaultMessageTypeConvention.cs
+++ b/Rebus.Tests/MessageType/TestDefaultMessageTypeConvention.cs
@@ -1,0 +1,36 @@
+﻿using NUnit.Framework;
+using Rebus.Exceptions;
+using Rebus.Extensions;
+using Rebus.Messages.MessageType;
+using Rebus.Topic;
+
+namespace Rebus.Tests.MessageType
+{
+    [TestFixture]
+    public class TestDefaultMessageTypeConvention
+    {
+        private class SimpleMessage
+        {
+            public string Something { get; set; }
+        }
+
+        private class SimpleMessageFromOtherBus
+        {
+            public string Something { get; set; }
+        }
+
+        [Test]
+        public void DefaultMessageTypeConventionUseGetAssExtension()
+        {
+            var typeconvention = new DefaultMessageTypeMapper();
+
+            var expected = typeof(SimpleMessage);
+            var name = typeconvention.GetMessageType(typeof(SimpleMessage));
+            var actual = typeconvention.GetTypeFromMessage(name);
+
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+    }
+   
+}

--- a/Rebus.Tests/MessageType/TestMappingMessageTypeConvention.cs
+++ b/Rebus.Tests/MessageType/TestMappingMessageTypeConvention.cs
@@ -1,0 +1,54 @@
+﻿using NUnit.Framework;
+using Rebus.Exceptions;
+using Rebus.Extensions;
+using Rebus.Messages.MessageType;
+using Rebus.Topic;
+
+namespace Rebus.Tests.MessageType
+{
+    [TestFixture]
+    public class TestMappingMessageTypeConvention
+    {
+
+        private class SimpleMessage
+        {
+            public string Something { get; set; }
+        }
+
+        private class SimpleMessageFromOtherBus
+        {
+            public string Something { get; set; }
+        }
+
+        [Test]
+        public void MappingMessageTypeConventionUseGetAssExtension()
+        {
+            var typeconvention = new MessageTypeMapper();
+            typeconvention.Map<SimpleMessage>("simpleMessage");
+
+            var typeconventionotherbus = new MessageTypeMapper();
+            typeconventionotherbus.Map<SimpleMessageFromOtherBus>("simpleMessage");
+
+            var expected = typeof(SimpleMessageFromOtherBus);
+            var name = typeconvention.GetMessageType(typeof(SimpleMessage));
+            var actual = typeconventionotherbus.GetTypeFromMessage(name);
+
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+
+        [Test]
+        public void MappingMessageTypeConventionThrowExceptionIfNotUnique()
+        {
+            void CheckFunction()
+            {
+                var typeconvention = new MessageTypeMapper();
+                typeconvention.Map<SimpleMessage>("simpleMessage");
+                typeconvention.Map<SimpleMessageFromOtherBus>("simpleMessage");
+            }
+
+            Assert.Throws(typeof(RebusConfigurationException), CheckFunction);
+        }
+
+    }
+}

--- a/Rebus.Tests/MessageType/TestMappingMessageTypeConventionIntegrationTest.cs
+++ b/Rebus.Tests/MessageType/TestMappingMessageTypeConventionIntegrationTest.cs
@@ -1,0 +1,118 @@
+﻿using NUnit.Framework;
+using Rebus.Activation;
+using Rebus.Bus;
+using Rebus.Config;
+using Rebus.DataBus.InMem;
+using Rebus.Handlers;
+using Rebus.Messages.MessageType;
+using Rebus.Persistence.InMem;
+using Rebus.Routing.TypeBased;
+using Rebus.Tests.Contracts;
+using Rebus.Tests.Contracts.Extensions;
+using Rebus.Transport.InMem;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Rebus.Tests.MessageType
+{
+    [TestFixture]
+    public class TestMappingMessageTypeMapperIntegrationTest : FixtureBase
+    {
+        const int limit = 2048;
+
+        InMemorySubscriberStore _subscriberStore;
+        InMemNetwork _network;
+        InMemDataStore _dataStore;
+        const string SenderQueue = "sender.queue";
+        const string ReceiverQueue = "receiver.queue";
+
+        protected override void SetUp()
+        {
+            _subscriberStore = new InMemorySubscriberStore();
+            _network = new InMemNetwork();
+            _dataStore = new InMemDataStore();
+        }
+
+
+        IBus GetSender()
+        {
+            var activator = new BuiltinHandlerActivator();
+
+            Using(activator);
+
+            return Configure.With(activator)
+                .MessageTypes(t =>
+                {
+                    t.MapMessageType()
+                        .Map<SimpleMessage>("simplemessage");
+                })
+                .Transport(t => t.UseInMemoryTransport(_network, SenderQueue))
+                .Subscriptions(s => s.StoreInMemory(_subscriberStore))
+                .DataBus(d => d.StoreInMemory(_dataStore))
+                .Routing(r =>
+                {
+                    r.TypeBased().Map<SimpleMessage>(ReceiverQueue);
+                })
+                .Start();
+        }
+
+        IBus GetReceiver(Func<SimpleMessage2, Task> action)
+        {
+            var activator = new BuiltinHandlerActivator();
+
+            Using(activator);
+
+            activator.Handle<SimpleMessage2>(action);
+
+            return Configure.With(activator)
+                .MessageTypes(t =>
+                {
+                    t.MapMessageType()
+                        .Map<SimpleMessage2>("simplemessage");
+                })
+                .Transport(t => t.UseInMemoryTransport(_network, ReceiverQueue))
+                .Subscriptions(s => s.StoreInMemory(_subscriberStore))
+                .DataBus(d => d.StoreInMemory(_dataStore))
+                .Start();
+        }
+
+        private class SimpleMessage
+        {
+            public string Something { get; set; }
+        }
+
+        private class SimpleMessage2
+        {
+            public string Something { get; set; }
+        }
+
+        [Test]
+        public async Task CorrectlySerializeAndDeserializeWhenUswMessageMapper()
+        {
+            var sendText = "TEST_TEST";
+            string recivedText = null;
+            var receivedBusReset = new ManualResetEvent(false);
+
+            var sender = GetSender();
+            var receiver = GetReceiver((SimpleMessage2 message) => {
+                recivedText = message.Something;
+                receivedBusReset.Set();
+                return Task.FromResult(0);
+            });
+
+            await receiver.Subscribe<SimpleMessage2>();
+
+            //await sender.Send(new SimpleMessage() { Something = sendText });
+            await sender.Publish(new SimpleMessage() { Something = sendText });
+
+            receivedBusReset.WaitOrDie(TimeSpan.FromSeconds(2));
+
+            Assert.AreEqual(sendText, recivedText);
+        }
+
+    }
+}

--- a/Rebus.Tests/Profiling/TestDispatchPerformance.cs
+++ b/Rebus.Tests/Profiling/TestDispatchPerformance.cs
@@ -8,6 +8,7 @@ using Rebus.Activation;
 using Rebus.Config;
 using Rebus.Logging;
 using Rebus.Messages;
+using Rebus.Messages.MessageType;
 using Rebus.Pipeline;
 using Rebus.Pipeline.Invokers;
 using Rebus.Profiling;
@@ -100,7 +101,7 @@ Stats:
                     })
                     .Start();
 
-                var serializer = new JsonSerializer();
+                var serializer = new JsonSerializer(new DefaultMessageTypeMapper());
                 var boy = new SomeMessage("hello there!");
 
                 for(var counter = 0; counter < numberOfMessages; counter++)

--- a/Rebus.Tests/Serialization/JsonSerializerFactory.cs
+++ b/Rebus.Tests/Serialization/JsonSerializerFactory.cs
@@ -1,3 +1,4 @@
+using Rebus.Messages.MessageType;
 using Rebus.Serialization;
 using Rebus.Serialization.Json;
 using Rebus.Tests.Contracts.Serialization;
@@ -8,7 +9,7 @@ namespace Rebus.Tests.Serialization
     {
         public ISerializer GetSerializer()
         {
-            return new JsonSerializer();
+            return new JsonSerializer(new DefaultMessageTypeMapper());
         }
     }
 }

--- a/Rebus.Tests/Serialization/TestJsonSerializer.cs
+++ b/Rebus.Tests/Serialization/TestJsonSerializer.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Newtonsoft.Json;
 using NUnit.Framework;
 using Rebus.Messages;
+using Rebus.Messages.MessageType;
 using Rebus.Tests.Contracts;
 using JsonSerializer = Rebus.Serialization.Json.JsonSerializer;
 #pragma warning disable 4014
@@ -20,7 +21,7 @@ namespace Rebus.Tests.Serialization
 
         protected override void SetUp()
         {
-            _serializer = new JsonSerializer();
+            _serializer = new JsonSerializer(new DefaultMessageTypeMapper()) ;
         }
 
         /*
@@ -70,7 +71,7 @@ Made 274822 iterations in 5s
         [Test]
         public async Task WorksWithoutFullTypeNameHandlingToo()
         {
-            var simpleSerializer = new JsonSerializer(new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.None });
+            var simpleSerializer = new JsonSerializer(new DefaultMessageTypeMapper(), new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.None });
             var message = new RandomMessage("hei allihoppa");
             var transportMessage = await simpleSerializer.Serialize(new Message(new Dictionary<string, string>(), message));
             var roundtrippedMessage = (await simpleSerializer.Deserialize(transportMessage)).Body;

--- a/Rebus.Tests/Topic/TestCustomTopicConventionIntegrationTest.cs
+++ b/Rebus.Tests/Topic/TestCustomTopicConventionIntegrationTest.cs
@@ -1,0 +1,114 @@
+﻿using NUnit.Framework;
+using Rebus.Activation;
+using Rebus.Bus;
+using Rebus.Bus.Advanced;
+using Rebus.Config;
+using Rebus.DataBus.InMem;
+using Rebus.Extensions;
+using Rebus.Handlers;
+using Rebus.Persistence.InMem;
+using Rebus.Routing.TypeBased;
+using Rebus.Tests.Contracts;
+using Rebus.Tests.Contracts.Extensions;
+using Rebus.Topic;
+using Rebus.Transport.InMem;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Rebus.Tests.Topic
+{
+    [TestFixture]
+    public class TestCustomTopicConventionIntegrationTest : FixtureBase
+    {
+        const int limit = 2048;
+
+        InMemorySubscriberStore _subscriberStore;
+        InMemNetwork _network;
+        InMemDataStore _dataStore;
+        const string SenderQueue = "sender.queue";
+        const string ReceiverQueue = "receiver.queue";
+
+        protected override void SetUp()
+        {
+            _subscriberStore = new InMemorySubscriberStore();
+            _network = new InMemNetwork();
+            _dataStore = new InMemDataStore();
+        }
+
+
+        IBus GetSender()
+        {
+            var activator = new BuiltinHandlerActivator();
+
+            Using(activator);
+
+            return Configure.With(activator)
+                .Options(o => o.Register<ITopicNameConvention>(c => new PrefixTopicNameConvention()))
+                .Transport(t => t.UseInMemoryTransport(_network, SenderQueue))
+                .Subscriptions(s => s.StoreInMemory(_subscriberStore))
+                .DataBus(d => d.StoreInMemory(_dataStore))
+                .Routing(r =>
+                {
+                    r.TypeBased().Map<SimpleMessage>(ReceiverQueue);
+                })
+                .Start();
+        }
+
+        IBus GetReceiver(Func<SimpleMessage, Task> action)
+        {
+            var activator = new BuiltinHandlerActivator();
+
+            Using(activator);
+
+            activator.Handle<SimpleMessage>(action);
+
+            return Configure.With(activator)
+                .Options(o => o.Register<ITopicNameConvention>(c => new PrefixTopicNameConvention()))
+                .Transport(t => t.UseInMemoryTransport(_network, ReceiverQueue))
+                .Subscriptions(s => s.StoreInMemory(_subscriberStore))
+                .DataBus(d => d.StoreInMemory(_dataStore))
+                .Start();
+        }
+
+
+        public class PrefixTopicNameConvention : ITopicNameConvention
+        {
+            public string GetTopic(Type eventType)
+            {
+                return "PREFIX_" + eventType.GetSimpleAssemblyQualifiedName();
+            }
+        }
+
+        private class SimpleMessage
+        {
+            public string Something { get; set; }
+        }
+
+        [Test]
+        public async Task CorrectlySerializeAndDeserializeWhenUseCustomTopic()
+        {
+            var sendText = "TEST_TEST";
+            string recivedText = null;
+            var receivedBusReset = new ManualResetEvent(false);
+
+            var sender = GetSender();
+            var receiver = GetReceiver((SimpleMessage message) => {
+                recivedText = message.Something;
+                receivedBusReset.Set();
+                return Task.FromResult(0);
+            });
+
+            await receiver.Subscribe<SimpleMessage>();
+
+            //await sender.Send(new SimpleMessage() { Something = sendText });
+            await sender.Publish(new SimpleMessage() { Something = sendText });
+
+            receivedBusReset.WaitOrDie(TimeSpan.FromSeconds(2));
+
+            Assert.AreEqual(sendText, recivedText);
+        }
+
+
+    }
+}

--- a/Rebus.Tests/Topic/TestDefaultTopicNameConvention.cs
+++ b/Rebus.Tests/Topic/TestDefaultTopicNameConvention.cs
@@ -1,5 +1,7 @@
 ﻿using NUnit.Framework;
 using Rebus.Extensions;
+using Rebus.Messages.MessageType;
+using Rebus.Tests.Contracts;
 using Rebus.Topic;
 
 namespace Rebus.Tests.Topic
@@ -10,9 +12,10 @@ namespace Rebus.Tests.Topic
         [Test]
         public void DefaultTopicNameConventionUseGetAssExtension()
         {
-            var convention = new DefaultTopicNameConvention();
+            var messageTypeConvetion = new DefaultMessageTypeMapper();
+            var convention = new DefaultTopicNameConvention(messageTypeConvetion);
 
-            var expected = typeof(SimpleMessage).GetSimpleAssemblyQualifiedName();
+            var expected = messageTypeConvetion.GetMessageType(typeof(SimpleMessage));
             var actual = convention.GetTopic(typeof(SimpleMessage));
 
             Assert.That(actual, Is.EqualTo(expected));

--- a/Rebus/Config/RebusConfigurer.cs
+++ b/Rebus/Config/RebusConfigurer.cs
@@ -130,6 +130,9 @@ namespace Rebus.Config
             return this;
         }
 
+        /// <summary>
+        /// Configures how Rebus generate message types by allowing for choosing which implementation of <see cref="IMessageTypeMapper"/> to use
+        /// </summary>
         public RebusConfigurer MessageTypes(Action<StandardConfigurer<IMessageTypeMapper>> configurer)
         {
             if (configurer == null) throw new ArgumentNullException(nameof(configurer));

--- a/Rebus/Messages/MessageType/DefaultMessageTypeMapper.cs
+++ b/Rebus/Messages/MessageType/DefaultMessageTypeMapper.cs
@@ -8,6 +8,9 @@ namespace Rebus.Messages.MessageType
     /// </summary>
     public class DefaultMessageTypeMapper : IMessageTypeMapper
     {
+        /// <summary>
+        /// Is Assembly name used
+        /// </summary>
         public bool UseTypeNameHandling => true;
 
         /// <summary>

--- a/Rebus/Messages/MessageType/DefaultMessageTypeMapper.cs
+++ b/Rebus/Messages/MessageType/DefaultMessageTypeMapper.cs
@@ -4,8 +4,7 @@ using Rebus.Extensions;
 namespace Rebus.Messages.MessageType
 {
     /// <summary>
-    /// Default convention to name message type after their "short assembly-qualified type names", which is
-    /// an assembly- and namespace-qualified type name without assembly version and public key token info.
+    /// Default Mapper for message type on "short assembly-qualified type names"
     /// </summary>
     public class DefaultMessageTypeMapper : IMessageTypeMapper
     {
@@ -19,6 +18,9 @@ namespace Rebus.Messages.MessageType
             return messageType.GetSimpleAssemblyQualifiedName();
         }
 
+        /// <summary>
+        /// Returns the type based on header type message
+        /// </summary>
         public Type GetTypeFromMessage(string messageType)
         {
             try

--- a/Rebus/Messages/MessageType/DefaultMessageTypeMapper.cs
+++ b/Rebus/Messages/MessageType/DefaultMessageTypeMapper.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using Rebus.Extensions;
+
+namespace Rebus.Messages.MessageType
+{
+    /// <summary>
+    /// Default convention to name message type after their "short assembly-qualified type names", which is
+    /// an assembly- and namespace-qualified type name without assembly version and public key token info.
+    /// </summary>
+    public class DefaultMessageTypeMapper : IMessageTypeMapper
+    {
+        public bool UseTypeNameHandling => true;
+
+        /// <summary>
+        /// Returns the header type name based on type of message
+        /// </summary>
+        public string GetMessageType(Type messageType)
+        {
+            return messageType.GetSimpleAssemblyQualifiedName();
+        }
+
+        public Type GetTypeFromMessage(string messageType)
+        {
+            try
+            {
+                return Type.GetType(messageType);
+            }
+            catch (Exception exception)
+            {
+                throw new FormatException($"Could not get .NET type named '{messageType}'", exception);
+            }
+        }
+    }
+}

--- a/Rebus/Messages/MessageType/IMessageTypeMapper.cs
+++ b/Rebus/Messages/MessageType/IMessageTypeMapper.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Rebus.Messages.MessageType
+{
+    /// <summary>
+    /// Defines the rules to header type of message
+    /// </summary>
+    public interface IMessageTypeMapper
+    {
+        /// <summary>
+        /// Returns the header type name based on type of message
+        /// </summary>
+        string GetMessageType(Type messageType);
+
+        Type GetTypeFromMessage(string messageType);
+
+        bool UseTypeNameHandling { get; }
+    }
+}

--- a/Rebus/Messages/MessageType/IMessageTypeMapper.cs
+++ b/Rebus/Messages/MessageType/IMessageTypeMapper.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace Rebus.Messages.MessageType
 {
     /// <summary>
-    /// Defines the rules to header type of message
+    /// Mapper for message type
     /// </summary>
     public interface IMessageTypeMapper
     {
@@ -16,8 +16,14 @@ namespace Rebus.Messages.MessageType
         /// </summary>
         string GetMessageType(Type messageType);
 
+        /// <summary>
+        /// Returns the type based on header type message
+        /// </summary>
         Type GetTypeFromMessage(string messageType);
 
+        /// <summary>
+        /// Returns true if serializer can use assembly-qualified to message serialization and deserialization
+        /// </summary>
         bool UseTypeNameHandling { get; }
     }
 }

--- a/Rebus/Messages/MessageType/MessageTypeMapper.cs
+++ b/Rebus/Messages/MessageType/MessageTypeMapper.cs
@@ -7,8 +7,8 @@ using Rebus.Extensions;
 namespace Rebus.Messages.MessageType
 {
     /// <summary>
-    /// Default convention to name message type after their "short assembly-qualified type names", which is
-    /// an assembly- and namespace-qualified type name without assembly version and public key token info.
+    /// MessageTypeMapper permit to configure mapping of class to relative 
+    /// header type used in serialization and deserialization
     /// </summary>
     public class MessageTypeMapper : IMessageTypeMapper
     {
@@ -43,6 +43,9 @@ namespace Rebus.Messages.MessageType
             return tuple.Name;
         }
 
+        /// <summary>
+        /// Returns the type based on header type message
+        /// </summary>
         public Type GetTypeFromMessage(string messageType)
         {
             var tuple = mappedMessageTypes.FirstOrDefault(t => t.Name == messageType);
@@ -53,6 +56,10 @@ namespace Rebus.Messages.MessageType
             return tuple.Type;            
         }
 
+
+        /// <summary>
+        /// MessageTypeMapper not use assembly name for mapping
+        /// </summary>
         public bool UseTypeNameHandling => false;
     }
 }

--- a/Rebus/Messages/MessageType/MessageTypeMapper.cs
+++ b/Rebus/Messages/MessageType/MessageTypeMapper.cs
@@ -14,11 +14,23 @@ namespace Rebus.Messages.MessageType
     {
         readonly HashSet<(Type Type, string Name)> mappedMessageTypes = new HashSet<(Type Type, string Name)>();
 
+        /// <summary>
+        /// Map class to custom name
+        /// </summary>
+        /// <typeparam name="T">message type</typeparam>
+        /// <param name="name">custom name</param>
+        /// <returns></returns>
         public MessageTypeMapper Map<T>(string name)
         {
             return this.Map(typeof(T), name);
         }
 
+        /// <summary>
+        /// Map class to custom name
+        /// </summary>
+        /// <param name="type">message type</param>
+        /// <param name="name">custom name</param>
+        /// <returns></returns>
         public MessageTypeMapper Map(Type type, string name)
         {
             if (mappedMessageTypes.Any(t => t.Name == name))

--- a/Rebus/Messages/MessageType/MessageTypeMapper.cs
+++ b/Rebus/Messages/MessageType/MessageTypeMapper.cs
@@ -65,7 +65,7 @@ namespace Rebus.Messages.MessageType
             {
                 throw new FormatException($"Could not get .NET type named '{messageType}'");
             }
-            return tuple.Type;            
+            return tuple.Type;
         }
 
 

--- a/Rebus/Messages/MessageType/MessageTypeMapper.cs
+++ b/Rebus/Messages/MessageType/MessageTypeMapper.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Rebus.Exceptions;
+using Rebus.Extensions;
+
+namespace Rebus.Messages.MessageType
+{
+    /// <summary>
+    /// Default convention to name message type after their "short assembly-qualified type names", which is
+    /// an assembly- and namespace-qualified type name without assembly version and public key token info.
+    /// </summary>
+    public class MessageTypeMapper : IMessageTypeMapper
+    {
+        readonly HashSet<(Type Type, string Name)> mappedMessageTypes = new HashSet<(Type Type, string Name)>();
+
+        public MessageTypeMapper Map<T>(string name)
+        {
+            return this.Map(typeof(T), name);
+        }
+
+        public MessageTypeMapper Map(Type type, string name)
+        {
+            if (mappedMessageTypes.Any(t => t.Name == name))
+            {
+                throw new RebusConfigurationException($"Message type '{name}' must be unique when use {nameof(MessageTypeMapper)}");
+            }
+
+            mappedMessageTypes.Add((Type: type, Name: name));
+            return this;
+        }
+
+        /// <summary>
+        /// Returns the header type name based on type of message
+        /// </summary>
+        public string GetMessageType(Type messageType)
+        {
+            var tuple = mappedMessageTypes.FirstOrDefault(t => t.Type == messageType);
+            if (String.IsNullOrEmpty(tuple.Name))
+            {
+                throw new RebusConfigurationException($"Message type '{messageType.Name}' must be registred when use {nameof(MessageTypeMapper)}");
+            }
+            return tuple.Name;
+        }
+
+        public Type GetTypeFromMessage(string messageType)
+        {
+            var tuple = mappedMessageTypes.FirstOrDefault(t => t.Name == messageType);
+            if (tuple.Type == null)
+            {
+                throw new FormatException($"Could not get .NET type named '{messageType}'");
+            }
+            return tuple.Type;            
+        }
+
+        public bool UseTypeNameHandling => false;
+    }
+}

--- a/Rebus/Messages/MessageType/MessageTypeMapperConfigurationExtensions.cs
+++ b/Rebus/Messages/MessageType/MessageTypeMapperConfigurationExtensions.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Rebus.Config;
+using Rebus.Messages.MessageType;
+
+namespace Rebus.Messages.MessageType
+{
+
+    public static class MessageTypeMapperConfigurationExtensions
+    {
+
+        public static void MapMessageType(this StandardConfigurer<IMessageTypeMapper> configurer, Action<MessageTypeMapper> mappingAction)
+        {
+            if (configurer == null) throw new ArgumentNullException(nameof(configurer));
+
+            configurer.Register(c =>
+            {
+                var messagetypeConvetion = new MessageTypeMapper();
+                mappingAction(messagetypeConvetion);
+                return messagetypeConvetion;
+            });
+        }
+
+        /// <summary>
+        /// Configures Rebus to use type-based routing
+        /// </summary>
+        public static MessageTypeMapperConfigurationBuilder MapMessageType(this StandardConfigurer<IMessageTypeMapper> configurer)
+        {
+            var builder = new MessageTypeMapperConfigurationBuilder();
+            configurer.Register(c => builder.Build());
+            return builder;
+        }
+
+        /// <summary>
+        /// Type-based routing configuration builder that can be called fluently to map message types to their owning endpoints
+        /// </summary>
+        public class MessageTypeMapperConfigurationBuilder
+        {
+            /// <summary>
+            /// We use this way of storing configuration actions in order to preserve the order
+            /// </summary>
+            readonly List<Action<MessageTypeMapper>> _configurationActions = new List<Action<MessageTypeMapper>>();
+
+            internal MessageTypeMapperConfigurationBuilder()
+            {
+            }
+
+            /// <summary>
+            /// Maps <paramref name="destinationAddress"/> as the owner of the <typeparamref name="TMessage"/> message type
+            /// </summary>
+            public MessageTypeMapperConfigurationBuilder Map<TMessage>(string destinationAddress)
+            {
+                _configurationActions.Add(r => r.Map<TMessage>(destinationAddress));
+                return this;
+            }
+
+            /// <summary>
+            /// Maps <paramref name="destinationAddress"/> as the owner of the <paramref name="messageType"/> message type
+            /// </summary>
+            public MessageTypeMapperConfigurationBuilder Map(Type messageType, string destinationAddress)
+            {
+                _configurationActions.Add(r => r.Map(messageType, destinationAddress));
+                return this;
+            }
+
+            internal MessageTypeMapper Build()
+            {
+                var router = new MessageTypeMapper();
+
+                foreach (var action in _configurationActions)
+                {
+                    action(router);
+                }
+
+                return router;
+            }
+        }
+
+
+    }
+}

--- a/Rebus/Messages/MessageType/MessageTypeMapperConfigurationExtensions.cs
+++ b/Rebus/Messages/MessageType/MessageTypeMapperConfigurationExtensions.cs
@@ -6,24 +6,15 @@ using Rebus.Messages.MessageType;
 
 namespace Rebus.Messages.MessageType
 {
-
+    /// <summary>
+    /// Configuration extensions for configuring message type mapper 
+    /// (i.e. when you cannot reuse same class between application)
+    /// </summary>
     public static class MessageTypeMapperConfigurationExtensions
     {
 
-        public static void MapMessageType(this StandardConfigurer<IMessageTypeMapper> configurer, Action<MessageTypeMapper> mappingAction)
-        {
-            if (configurer == null) throw new ArgumentNullException(nameof(configurer));
-
-            configurer.Register(c =>
-            {
-                var messagetypeConvetion = new MessageTypeMapper();
-                mappingAction(messagetypeConvetion);
-                return messagetypeConvetion;
-            });
-        }
-
         /// <summary>
-        /// Configures Rebus to use type-based routing
+        /// Configures Rebus to use message type mapper configurable
         /// </summary>
         public static MessageTypeMapperConfigurationBuilder MapMessageType(this StandardConfigurer<IMessageTypeMapper> configurer)
         {
@@ -33,7 +24,8 @@ namespace Rebus.Messages.MessageType
         }
 
         /// <summary>
-        /// Type-based routing configuration builder that can be called fluently to map message types to their owning endpoints
+        /// Configuration Builder for mapping message header type to a specific class
+        /// Can be use when you cannot reuse same class. or using differente application codes
         /// </summary>
         public class MessageTypeMapperConfigurationBuilder
         {
@@ -47,20 +39,20 @@ namespace Rebus.Messages.MessageType
             }
 
             /// <summary>
-            /// Maps <paramref name="destinationAddress"/> as the owner of the <typeparamref name="TMessage"/> message type
+            /// Maps <paramref name="typename"/> as the "type" of the <typeparamref name="TMessage"/> message type
             /// </summary>
-            public MessageTypeMapperConfigurationBuilder Map<TMessage>(string destinationAddress)
+            public MessageTypeMapperConfigurationBuilder Map<TMessage>(string typename)
             {
-                _configurationActions.Add(r => r.Map<TMessage>(destinationAddress));
+                _configurationActions.Add(r => r.Map<TMessage>(typename));
                 return this;
             }
 
             /// <summary>
-            /// Maps <paramref name="destinationAddress"/> as the owner of the <paramref name="messageType"/> message type
+            /// Maps <paramref name="typename"/> as "type" of the <paramref name="messageType"/> message type
             /// </summary>
-            public MessageTypeMapperConfigurationBuilder Map(Type messageType, string destinationAddress)
+            public MessageTypeMapperConfigurationBuilder Map(Type messageType, string typename)
             {
-                _configurationActions.Add(r => r.Map(messageType, destinationAddress));
+                _configurationActions.Add(r => r.Map(messageType, typename));
                 return this;
             }
 

--- a/Rebus/Pipeline/Send/AssignDefaultHeadersStep.cs
+++ b/Rebus/Pipeline/Send/AssignDefaultHeadersStep.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Rebus.Transport;
 using Rebus.Extensions;
 using Rebus.Time;
+using Rebus.Messages.MessageType;
 
 namespace Rebus.Pipeline.Send
 {
@@ -28,6 +29,7 @@ namespace Rebus.Pipeline.Send
     public class AssignDefaultHeadersStep : IOutgoingStep
     {
         readonly IRebusTime _rebusTime;
+        readonly IMessageTypeMapper _messageTypeMapper;
         readonly bool _hasOwnAddress;
         readonly string _senderAddress;
         readonly string _returnAddress;
@@ -35,9 +37,10 @@ namespace Rebus.Pipeline.Send
         /// <summary>
         /// Constructs the step, getting the input queue address from the given <see cref="ITransport"/>
         /// </summary>
-        public AssignDefaultHeadersStep(ITransport transport, IRebusTime rebusTime, string defaultReturnAddressOrNull)
+        public AssignDefaultHeadersStep(ITransport transport, IMessageTypeMapper messageTypeMapper, IRebusTime rebusTime, string defaultReturnAddressOrNull)
         {
             _rebusTime = rebusTime ?? throw new ArgumentNullException(nameof(rebusTime));
+            _messageTypeMapper = messageTypeMapper ?? throw new ArgumentNullException(nameof(rebusTime));
             _senderAddress = transport.Address;
             _returnAddress = defaultReturnAddressOrNull ?? transport.Address;
             _hasOwnAddress = !string.IsNullOrWhiteSpace(_senderAddress);
@@ -75,7 +78,7 @@ namespace Rebus.Pipeline.Send
 
             if (!headers.ContainsKey(Headers.Type))
             {
-                headers[Headers.Type] = messageType.GetSimpleAssemblyQualifiedName();
+                headers[Headers.Type] = _messageTypeMapper.GetMessageType(messageType);
             }
 
             await next();

--- a/Rebus/Rebus.csproj
+++ b/Rebus/Rebus.csproj
@@ -74,6 +74,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' OR '$(TargetFramework)' == 'net46'">
     <Reference Include="System" />

--- a/Rebus/Serialization/Json/JsonSerializer.cs
+++ b/Rebus/Serialization/Json/JsonSerializer.cs
@@ -150,7 +150,7 @@ namespace Rebus.Serialization.Json
         Type GetTypeOrNull(TransportMessage transportMessage)
         {
             if (!transportMessage.Headers.TryGetValue(Headers.Type, out var typeName)) return null;
-            return _messageTypeMapper.GetTypeFromMessage(typeName);
+            return TypeCache.GetOrAdd(typeName, (t) => _messageTypeMapper.GetTypeFromMessage(t));
         }
 
         object Deserialize(string bodyString, Type type)

--- a/Rebus/Serialization/Json/NewtonsoftJsonConfigurationExtensions.cs
+++ b/Rebus/Serialization/Json/NewtonsoftJsonConfigurationExtensions.cs
@@ -2,6 +2,7 @@
 using System.Text;
 using Newtonsoft.Json;
 using Rebus.Config;
+using Rebus.Messages.MessageType;
 
 namespace Rebus.Serialization.Json
 {
@@ -69,7 +70,7 @@ namespace Rebus.Serialization.Json
         {
             if (configurer == null) throw new ArgumentNullException(nameof(configurer));
 
-            configurer.Register(c => new JsonSerializer(settings, encoding ?? Encoding.UTF8));
+            configurer.Register(c => new JsonSerializer(c.Get<IMessageTypeMapper>(), settings, encoding ?? Encoding.UTF8));
         }
     }
 }

--- a/Rebus/Topic/DefaultTopicNameConvention.cs
+++ b/Rebus/Topic/DefaultTopicNameConvention.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Rebus.Extensions;
+using Rebus.Messages.MessageType;
 
 namespace Rebus.Topic
 {
@@ -9,13 +10,20 @@ namespace Rebus.Topic
     /// </summary>
     public class DefaultTopicNameConvention : ITopicNameConvention
     {
+        private IMessageTypeMapper _messageTypeMapper;
+
+        public DefaultTopicNameConvention(IMessageTypeMapper messageTypeMapper)
+        {
+            _messageTypeMapper = messageTypeMapper;
+        }
+
         /// <summary>
         /// Returns the default topic name based on the "short assembly-qualified type name", which is
         /// an assembly- and namespace-qualified type name without assembly version and public key token info.
         /// </summary>
         public string GetTopic(Type eventType)
         {
-            return eventType.GetSimpleAssemblyQualifiedName();
+            return _messageTypeMapper.GetMessageType(eventType);
         }
     }
 }

--- a/Rebus/Topic/DefaultTopicNameConvention.cs
+++ b/Rebus/Topic/DefaultTopicNameConvention.cs
@@ -12,6 +12,10 @@ namespace Rebus.Topic
     {
         private IMessageTypeMapper _messageTypeMapper;
 
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        /// <param name="messageTypeMapper"></param>
         public DefaultTopicNameConvention(IMessageTypeMapper messageTypeMapper)
         {
             _messageTypeMapper = messageTypeMapper;


### PR DESCRIPTION
Hi,
I submit this pullrequest in order to upgrade your SharedNothing example (https://github.com/rebus-org/RebusSamples/tree/master/SharedNothing)

I wanted a built-in way to manage message sharing not based on assembly name, without having to decorate/inject multiple classes.

Let me know if this works for you too
Thanks


---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
