### PR TITLE
Make FileSystemTransport backward compatible with Rebus 5

### DIFF
--- a/Rebus/Transport/FileSystem/FileSystemTransport.cs
+++ b/Rebus/Transport/FileSystem/FileSystemTransport.cs
@@ -350,7 +350,7 @@ namespace Rebus.Transport.FileSystem
 
             public void Complete(Guid unitOfWorkId, DateTimeOffset now, int index)
             {
-                var finalFilePath = Path.Combine(_destinationDirectoryPath, $"rebusmessage-{now:yyyyMMdd}-{now:HHmmss}-{unitOfWorkId:N}-{index:000000}.json");
+                var finalFilePath = Path.Combine(_destinationDirectoryPath, $"{now:yyyyMMdd}-{now:HHmmss}-{unitOfWorkId:N}-{index:000000}.rebusmessage.json");
                 var attempts = 0;
 
                 while (true)


### PR DESCRIPTION
Fixes https://github.com/rebus-org/Rebus/issues/859

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
