### PR TITLE
[Draft] - Circuit Breaker feature

### DIFF
--- a/Rebus.Tests/Rebus.Tests.csproj
+++ b/Rebus.Tests/Rebus.Tests.csproj
@@ -46,4 +46,7 @@
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Retry\CircuitBreaker\" />
+  </ItemGroup>
 </Project>

--- a/Rebus.Tests/Retry/CircuitBreaker/CircuitBreakerTests.cs
+++ b/Rebus.Tests/Retry/CircuitBreaker/CircuitBreakerTests.cs
@@ -1,0 +1,51 @@
+﻿using NUnit.Framework;
+using Rebus.Activation;
+using Rebus.Config;
+using Rebus.Retry.CircuitBreaker;
+using Rebus.Tests.Contracts;
+using Rebus.Transport.InMem;
+using System;
+using System.Threading.Tasks;
+
+namespace Rebus.Tests.Retry.CircuitBreaker
+{
+    [TestFixture]
+    public class CircuitBreakerTests : FixtureBase
+    {
+        [Test]
+        [Ignore("Temporary ignored, For some reason this test fails, even though worker count explicity set to 0, but worker count returns 1")]
+        public async Task Test()
+        {
+            var network = new InMemNetwork();
+
+            var receiver = Using(new BuiltinHandlerActivator());
+
+            var bus = Configure.With(receiver)
+                  .Transport(t => t.UseInMemoryTransport(network, "queue-a"))
+                  .Options(o =>
+                      {
+                          o.SetCircuitBreakers(c => c.OpenOn<MyCustomException>(1, trackingPeriodInSeconds: 10));
+                      }
+                  )
+                  .Start();
+
+            receiver.Handle<string>(async (buss, context, message) =>
+            {
+                await Task.FromResult(0);
+                throw new MyCustomException();
+            });
+
+            await bus.SendLocal("Uh oh, This is not gonna go well!");
+
+            await Task.Delay(5000);
+
+            var workerCount = bus.Advanced.Workers.Count;
+            Assert.That(workerCount, Is.EqualTo(0), $"Expected worker count to be '0' but was {workerCount}");
+        }
+
+        class MyCustomException : Exception
+        {
+
+        }
+    }
+}

--- a/Rebus.Tests/Retry/CircuitBreaker/CircuitBreakerTests.cs
+++ b/Rebus.Tests/Retry/CircuitBreaker/CircuitBreakerTests.cs
@@ -5,6 +5,7 @@ using Rebus.Retry.CircuitBreaker;
 using Rebus.Tests.Contracts;
 using Rebus.Transport.InMem;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Rebus.Tests.Retry.CircuitBreaker
@@ -12,19 +13,21 @@ namespace Rebus.Tests.Retry.CircuitBreaker
     [TestFixture]
     public class CircuitBreakerTests : FixtureBase
     {
+        // TODO: Fix this test
         [Test]
-        [Ignore("Temporary ignored, For some reason this test fails, even though worker count explicity set to 0, but worker count returns 1")]
-        public async Task Test()
+        [Ignore("Temporary ignored, For some reason this test fails, even though worker count explicity set to 0, but worker count returns 1. " +
+            "This needs to be fixed before merge")] 
+        public async Task CircuitBreakerIntegrationTest()
         {
             var network = new InMemNetwork();
 
             var receiver = Using(new BuiltinHandlerActivator());
-
             var bus = Configure.With(receiver)
+                  .Logging(l => l.Trace())
                   .Transport(t => t.UseInMemoryTransport(network, "queue-a"))
                   .Options(o =>
                       {
-                          o.SetCircuitBreakers(c => c.OpenOn<MyCustomException>(1, trackingPeriodInSeconds: 10));
+                          o.EnableCircuitBreaker(c => c.OpenOn<MyCustomException>(1, trackingPeriodInSeconds: 10));
                       }
                   )
                   .Start();
@@ -38,6 +41,7 @@ namespace Rebus.Tests.Retry.CircuitBreaker
             await bus.SendLocal("Uh oh, This is not gonna go well!");
 
             await Task.Delay(5000);
+
 
             var workerCount = bus.Advanced.Workers.Count;
             Assert.That(workerCount, Is.EqualTo(0), $"Expected worker count to be '0' but was {workerCount}");

--- a/Rebus.Tests/Retry/CircuitBreaker/ExceptionTypeCircuitBreakerTests.cs
+++ b/Rebus.Tests/Retry/CircuitBreaker/ExceptionTypeCircuitBreakerTests.cs
@@ -1,0 +1,72 @@
+﻿using NUnit.Framework;
+using Rebus.Retry.CircuitBreaker;
+using Rebus.Tests.Time;
+using Rebus.Time;
+using System;
+using System.Threading.Tasks;
+
+namespace Rebus.Tests.Retry.CircuitBreaker
+{
+    [TestFixture]
+    public class ExceptionTypeCircuitBreakerTests 
+    {
+        private IRebusTime time;
+
+
+        [SetUp]
+        public void Setup()
+        {
+            time = new FakeRebusTime();
+        }
+
+        [Test]
+        public void Trip_WithOneAttemptTrippedOnce_DoesOpenCircuit()
+        {
+            var sut = new ExceptionTypeCircuitBreaker(typeof(MyCustomException), new CircuitBreakerSettings(1, 2, 60), time);
+
+            sut.Trip(new MyCustomException());
+
+            Assert.That(sut.State, Is.EqualTo(CircuitBreakerState.Open));
+        }
+
+        [Test]
+        public void Trip_WithTwoAttemptTrippedOnce_DoesNotOpenCircuit()
+        {
+            var sut = new ExceptionTypeCircuitBreaker(typeof(MyCustomException), new CircuitBreakerSettings(2, 60, 60), time);
+
+            sut.Trip(new MyCustomException());
+
+            Assert.That(sut.State, Is.EqualTo(CircuitBreakerState.Closed));
+        }
+
+        [Test]
+        public async Task Trip_WithTwoAttemptTrippedTwice_OutSideTrackingPeriod_DoesNotOpenCircuit()
+        {
+            var sut = new ExceptionTypeCircuitBreaker(typeof(MyCustomException), new CircuitBreakerSettings(2, 2, 180), time);
+
+            sut.Trip(new MyCustomException());
+            await Task.Delay(TimeSpan.FromSeconds(3.1));
+            sut.Trip(new MyCustomException());
+
+
+            Assert.That(sut.State, Is.EqualTo(CircuitBreakerState.Closed));
+        }
+
+        [Test]
+        public async Task Trip_WithTwoAttemptTrippedTwice_InsideTrackingPeriod_DoesOpenCircuit()
+        {
+            var sut = new ExceptionTypeCircuitBreaker(typeof(MyCustomException), new CircuitBreakerSettings(2, 60, 180), time);
+
+            sut.Trip(new MyCustomException());
+            await Task.Delay(TimeSpan.FromSeconds(2.5));
+            sut.Trip(new MyCustomException());
+
+            Assert.That(sut.State, Is.EqualTo(CircuitBreakerState.Open));
+        }
+
+        class MyCustomException : Exception
+        {
+
+        }
+    }
+}

--- a/Rebus.Tests/Retry/CircuitBreaker/MainCircuitBreakerTests.cs
+++ b/Rebus.Tests/Retry/CircuitBreaker/MainCircuitBreakerTests.cs
@@ -1,0 +1,115 @@
+﻿using NUnit.Framework;
+using Rebus.Logging;
+using Rebus.Retry.CircuitBreaker;
+using Rebus.Threading;
+using Rebus.Threading.SystemThreadingTimer;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Rebus.Tests.Retry.CircuitBreaker
+{
+    [TestFixture]
+    public class MainCircuitBreakerTests 
+    {
+        IAsyncTaskFactory taskFactory;
+        IRebusLoggerFactory rebusLoggerFactory;
+
+        [SetUp]
+        public void Setup() 
+        {
+            rebusLoggerFactory = new ConsoleLoggerFactory(false);
+            taskFactory = new SystemThreadingTimerAsyncTaskFactory(rebusLoggerFactory);
+        }
+
+        [Test]
+        public void State_AllClosed_ReturnsClosed() 
+        {
+            var sut = new MainCircuitBreaker(new List<ICircuitBreaker>()
+            {
+                new FakeCircuitBreaker(CircuitBreakerState.Closed),
+                new FakeCircuitBreaker(CircuitBreakerState.Closed),
+                new FakeCircuitBreaker(CircuitBreakerState.Closed),
+            }, rebusLoggerFactory, taskFactory, null);
+
+
+            Assert.That(sut.State, Is.EqualTo(CircuitBreakerState.Closed));
+            Assert.IsTrue(sut.IsClosed);
+            Assert.IsFalse(sut.IsHalfOpen);
+            Assert.IsFalse(sut.IsOpen);
+        }
+
+        [Test]
+        public void State_OneHalfOpen_ReturnsHalfOpen()
+        {
+            var sut = new MainCircuitBreaker(new List<ICircuitBreaker>()
+            {
+                new FakeCircuitBreaker(CircuitBreakerState.Closed),
+                new FakeCircuitBreaker(CircuitBreakerState.HalfOpen),
+                new FakeCircuitBreaker(CircuitBreakerState.Closed),
+            }, rebusLoggerFactory, taskFactory, null);
+
+            Assert.That(sut.State, Is.EqualTo(CircuitBreakerState.HalfOpen));
+            Assert.IsFalse(sut.IsClosed);
+            Assert.IsTrue(sut.IsHalfOpen);
+            Assert.IsFalse(sut.IsOpen);
+        }
+
+        [Test]
+        public void State_OneOpen_ReturnsOpen()
+        {
+            var sut = new MainCircuitBreaker(new List<ICircuitBreaker>()
+            {
+                new FakeCircuitBreaker(CircuitBreakerState.Closed),
+                new FakeCircuitBreaker(CircuitBreakerState.Closed),
+                new FakeCircuitBreaker(CircuitBreakerState.Open),
+            }, new ConsoleLoggerFactory(false), taskFactory, null);
+
+            Assert.That(sut.State, Is.EqualTo(CircuitBreakerState.Open));
+            Assert.IsFalse(sut.IsClosed);
+            Assert.IsFalse(sut.IsHalfOpen);
+            Assert.IsTrue(sut.IsOpen);
+        }
+
+        [Test]
+        public void State_MixedBag_ReturnsOpen()
+        {
+            var sut = new MainCircuitBreaker(new List<ICircuitBreaker>()
+            {
+                new FakeCircuitBreaker(CircuitBreakerState.HalfOpen),
+                new FakeCircuitBreaker(CircuitBreakerState.Closed),
+                new FakeCircuitBreaker(CircuitBreakerState.Open),
+            }, rebusLoggerFactory, taskFactory, null);
+
+            Assert.That(sut.State, Is.EqualTo(CircuitBreakerState.Open));
+            Assert.IsFalse(sut.IsClosed);
+            Assert.IsFalse(sut.IsHalfOpen);
+            Assert.IsTrue(sut.IsOpen);
+        }
+
+        internal class FakeCircuitBreaker : ICircuitBreaker
+        {
+            public FakeCircuitBreaker(CircuitBreakerState state)
+            {
+                this.State = state;
+            }
+
+            public CircuitBreakerState State { get; private set; }
+
+            public bool IsClosed => State == CircuitBreakerState.Closed;
+
+            public bool IsHalfOpen => State == CircuitBreakerState.HalfOpen;
+
+            public bool IsOpen => State == CircuitBreakerState.Open;
+
+            public void Trip(Exception exception)
+            {
+            }
+
+            public async Task TryReset()
+            {
+                await Task.FromResult(0);
+            }
+        }
+    }
+}

--- a/Rebus.Tests/Retry/CircuitBreaker/MainCircuitBreakerTests.cs
+++ b/Rebus.Tests/Retry/CircuitBreaker/MainCircuitBreakerTests.cs
@@ -106,7 +106,7 @@ namespace Rebus.Tests.Retry.CircuitBreaker
             {
             }
 
-            public async Task TryReset()
+            public async Task Reset()
             {
                 await Task.FromResult(0);
             }

--- a/Rebus.Tests/Retry/CircuitBreaker/MainCircuitBreakerTests.cs
+++ b/Rebus.Tests/Retry/CircuitBreaker/MainCircuitBreakerTests.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using Rebus.Bus;
 using Rebus.Logging;
 using Rebus.Retry.CircuitBreaker;
 using Rebus.Threading;
@@ -15,11 +16,14 @@ namespace Rebus.Tests.Retry.CircuitBreaker
         IAsyncTaskFactory taskFactory;
         IRebusLoggerFactory rebusLoggerFactory;
 
+        BusLifetimeEvents busLifeTimeEvents;
+
         [SetUp]
         public void Setup() 
         {
             rebusLoggerFactory = new ConsoleLoggerFactory(false);
             taskFactory = new SystemThreadingTimerAsyncTaskFactory(rebusLoggerFactory);
+            busLifeTimeEvents = new BusLifetimeEvents();
         }
 
         [Test]
@@ -30,7 +34,7 @@ namespace Rebus.Tests.Retry.CircuitBreaker
                 new FakeCircuitBreaker(CircuitBreakerState.Closed),
                 new FakeCircuitBreaker(CircuitBreakerState.Closed),
                 new FakeCircuitBreaker(CircuitBreakerState.Closed),
-            }, rebusLoggerFactory, taskFactory, null);
+            }, rebusLoggerFactory, taskFactory, null, busLifeTimeEvents);
 
 
             Assert.That(sut.State, Is.EqualTo(CircuitBreakerState.Closed));
@@ -47,7 +51,7 @@ namespace Rebus.Tests.Retry.CircuitBreaker
                 new FakeCircuitBreaker(CircuitBreakerState.Closed),
                 new FakeCircuitBreaker(CircuitBreakerState.HalfOpen),
                 new FakeCircuitBreaker(CircuitBreakerState.Closed),
-            }, rebusLoggerFactory, taskFactory, null);
+            }, rebusLoggerFactory, taskFactory, null, busLifeTimeEvents);
 
             Assert.That(sut.State, Is.EqualTo(CircuitBreakerState.HalfOpen));
             Assert.IsFalse(sut.IsClosed);
@@ -63,7 +67,7 @@ namespace Rebus.Tests.Retry.CircuitBreaker
                 new FakeCircuitBreaker(CircuitBreakerState.Closed),
                 new FakeCircuitBreaker(CircuitBreakerState.Closed),
                 new FakeCircuitBreaker(CircuitBreakerState.Open),
-            }, new ConsoleLoggerFactory(false), taskFactory, null);
+            }, new ConsoleLoggerFactory(false), taskFactory, null, busLifeTimeEvents);
 
             Assert.That(sut.State, Is.EqualTo(CircuitBreakerState.Open));
             Assert.IsFalse(sut.IsClosed);
@@ -79,7 +83,7 @@ namespace Rebus.Tests.Retry.CircuitBreaker
                 new FakeCircuitBreaker(CircuitBreakerState.HalfOpen),
                 new FakeCircuitBreaker(CircuitBreakerState.Closed),
                 new FakeCircuitBreaker(CircuitBreakerState.Open),
-            }, rebusLoggerFactory, taskFactory, null);
+            }, rebusLoggerFactory, taskFactory, null, busLifeTimeEvents);
 
             Assert.That(sut.State, Is.EqualTo(CircuitBreakerState.Open));
             Assert.IsFalse(sut.IsClosed);

--- a/Rebus/Bus/BusLifetimeEvents.cs
+++ b/Rebus/Bus/BusLifetimeEvents.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Rebus.Retry.CircuitBreaker;
+using System;
 
 namespace Rebus.Bus
 {
@@ -33,6 +34,11 @@ namespace Rebus.Bus
         /// </summary>
         public event Action BusDisposed;
 
+        /// <summary>
+        /// Event that is raised when the circuit breaker is changing state. <see cref="CircuitBreakerState"/>
+        /// </summary>
+        public event Action<CircuitBreakerState> CircuitBreakerChanged;
+
         internal void RaiseBusStarting()
         {
             BusStarting?.Invoke();
@@ -56,6 +62,11 @@ namespace Rebus.Bus
         internal void RaiseWorkersStopped()
         {
             WorkersStopped?.Invoke();
+        }
+
+        internal void RaiseCircuitBreakerChanged(CircuitBreakerState state) 
+        {
+            CircuitBreakerChanged?.Invoke(state);
         }
     }
 }

--- a/Rebus/Rebus.csproj
+++ b/Rebus/Rebus.csproj
@@ -81,4 +81,7 @@
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Retry\CircuitBreaker\" />
+  </ItemGroup>
 </Project>

--- a/Rebus/Retry/CircuitBreaker/CircuitBreakerConfigurationExtensions.cs
+++ b/Rebus/Retry/CircuitBreaker/CircuitBreakerConfigurationExtensions.cs
@@ -32,6 +32,7 @@ namespace Rebus.Retry.CircuitBreaker
                 var asyncTaskFactory = c.Get<IAsyncTaskFactory>();
                 var rebusBus = c.Get<RebusBus>();
                 var circuitBreaker = new MainCircuitBreaker(circuitBreakers, loggerFactory, asyncTaskFactory, rebusBus);
+                optionsConfigurer.Register<IInitializable>(x => circuitBreaker);
 
                 return new CircuitBreakerErrorHandler(circuitBreaker, innerHandler, loggerFactory);
             });

--- a/Rebus/Retry/CircuitBreaker/CircuitBreakerConfigurationExtensions.cs
+++ b/Rebus/Retry/CircuitBreaker/CircuitBreakerConfigurationExtensions.cs
@@ -27,14 +27,16 @@ namespace Rebus.Retry.CircuitBreaker
 
             optionsConfigurer.Decorate<IErrorHandler>(c => 
             {
-                var innerHandler = c.Get<IErrorHandler>();
+                var innerErrorHandler = c.Get<IErrorHandler>();
                 var loggerFactory = c.Get<IRebusLoggerFactory>();
                 var asyncTaskFactory = c.Get<IAsyncTaskFactory>();
                 var rebusBus = c.Get<RebusBus>();
-                var circuitBreaker = new MainCircuitBreaker(circuitBreakers, loggerFactory, asyncTaskFactory, rebusBus);
+                var busLifetimeEvents = c.Get<BusLifetimeEvents>();
+                var circuitBreaker = new MainCircuitBreaker(circuitBreakers, loggerFactory, asyncTaskFactory, rebusBus, busLifetimeEvents);
+                
                 optionsConfigurer.Register<IInitializable>(x => circuitBreaker);
 
-                return new CircuitBreakerErrorHandler(circuitBreaker, innerHandler, loggerFactory);
+                return new CircuitBreakerErrorHandler(circuitBreaker, innerErrorHandler, loggerFactory);
             });
         }
 

--- a/Rebus/Retry/CircuitBreaker/CircuitBreakerConfigurationExtensions.cs
+++ b/Rebus/Retry/CircuitBreaker/CircuitBreakerConfigurationExtensions.cs
@@ -18,7 +18,7 @@ namespace Rebus.Retry.CircuitBreaker
         /// </summary>
         /// <param name="optionsConfigurer"></param>
         /// <param name="circuitBreakerBuilder"></param>
-        public static void SetCircuitBreakers(this OptionsConfigurer optionsConfigurer
+        public static void EnableCircuitBreaker(this OptionsConfigurer optionsConfigurer
             , Action<CircuitBreakerConfigurationBuilder> circuitBreakerBuilder) 
         {
             var builder = new CircuitBreakerConfigurationBuilder();

--- a/Rebus/Retry/CircuitBreaker/CircuitBreakerConfigurationExtensions.cs
+++ b/Rebus/Retry/CircuitBreaker/CircuitBreakerConfigurationExtensions.cs
@@ -1,0 +1,74 @@
+﻿using Rebus.Bus;
+using Rebus.Config;
+using Rebus.Logging;
+using Rebus.Threading;
+using Rebus.Time;
+using System;
+using System.Collections.Generic;
+
+namespace Rebus.Retry.CircuitBreaker
+{
+    /// <summary>
+    /// Configuration extensions for the Circuit breakers
+    /// </summary>
+    public static class CircuitBreakerConfigurationExtensions
+    {
+        /// <summary>
+        /// Enabling fluent configuration of circuit breakers
+        /// </summary>
+        /// <param name="optionsConfigurer"></param>
+        /// <param name="circuitBreakerBuilder"></param>
+        public static void SetCircuitBreakers(this OptionsConfigurer optionsConfigurer
+            , Action<CircuitBreakerConfigurationBuilder> circuitBreakerBuilder) 
+        {
+            var builder = new CircuitBreakerConfigurationBuilder();
+            circuitBreakerBuilder?.Invoke(builder);
+            var circuitBreakers = builder.Build();
+
+            optionsConfigurer.Decorate<IErrorHandler>(c => 
+            {
+                var innerHandler = c.Get<IErrorHandler>();
+                var loggerFactory = c.Get<IRebusLoggerFactory>();
+                var asyncTaskFactory = c.Get<IAsyncTaskFactory>();
+                var rebusBus = c.Get<RebusBus>();
+                var circuitBreaker = new MainCircuitBreaker(circuitBreakers, loggerFactory, asyncTaskFactory, rebusBus);
+
+                return new CircuitBreakerErrorHandler(circuitBreaker, innerHandler, loggerFactory);
+            });
+        }
+
+        /// <summary>
+        /// Configuration builder to fluently register circuit breakers
+        /// </summary>
+        public class CircuitBreakerConfigurationBuilder
+        {
+
+            private readonly IList<ICircuitBreaker> _circuitBreakerStores;
+
+            internal CircuitBreakerConfigurationBuilder()
+            {
+                _circuitBreakerStores = new List<ICircuitBreaker>();
+            }
+
+            /// <summary>
+            /// Register a circuit breaker based on an <typeparamref name="TException"/>
+            /// </summary>
+            /// <typeparam name="TException"></typeparam>
+            public CircuitBreakerConfigurationBuilder OpenOn<TException>(
+                int attempts = CircuitBreakerSettings.DefaultAttempts
+                , int trackingPeriodInSeconds = CircuitBreakerSettings.DefaultTrackingPeriodInSeconds
+                , int resetIntervalInSeconds = CircuitBreakerSettings.DefaultResetIntervalInSeconds)
+                where TException : Exception
+            {
+                var settings = new CircuitBreakerSettings(attempts, trackingPeriodInSeconds, resetIntervalInSeconds);
+                _circuitBreakerStores.Add(new ExceptionTypeCircuitBreaker(typeof(TException), settings, new DefaultRebusTime()));
+                return this;
+            }
+
+            internal IList<ICircuitBreaker> Build() 
+            {
+                return _circuitBreakerStores;
+            }
+        }   
+    }
+}

--- a/Rebus/Retry/CircuitBreaker/CircuitBreakerErrorHandler.cs
+++ b/Rebus/Retry/CircuitBreaker/CircuitBreakerErrorHandler.cs
@@ -1,0 +1,39 @@
+﻿using Rebus.Logging;
+using Rebus.Messages;
+using Rebus.Transport;
+using System;
+using System.Threading.Tasks;
+
+namespace Rebus.Retry.CircuitBreaker
+{
+    internal class CircuitBreakerErrorHandler : IErrorHandler
+    {
+        private readonly ICircuitBreaker circuitBreaker;
+        private readonly IErrorHandler innerErrorHandler;
+        private ILog _log;
+
+        public CircuitBreakerErrorHandler(ICircuitBreaker circuitBreaker, IErrorHandler innerErrorHandler
+            , IRebusLoggerFactory rebusLoggerFactory)
+        {
+            this.circuitBreaker = circuitBreaker;
+            this.innerErrorHandler = innerErrorHandler ?? throw new ArgumentNullException(nameof(innerErrorHandler));
+            _log = rebusLoggerFactory?.GetLogger<CircuitBreakerErrorHandler>() ?? throw new ArgumentNullException(nameof(rebusLoggerFactory));
+        }
+
+        public async Task HandlePoisonMessage(TransportMessage transportMessage, ITransactionContext transactionContext, Exception exception)
+        {
+            // The `IErrorHandler` is first trickered after a handler has failed 5 times
+            // This means, that if we have a faulty service throwing an exception, 
+            // the service still getting taxed at least 5 times before we trip 1 attempt.
+            // If we configure circuit breaker to have 5 attempts within an interval, then the service will get taxed 25 times!
+            // Question is whether we should move this logic away from the IErrorHandler and into a IIncomingStep, to ensure that an external dependency
+            // is taxed more than necessary.
+            
+            // TODO: What to do?
+
+            circuitBreaker.Trip(exception);
+                        
+            await innerErrorHandler.HandlePoisonMessage(transportMessage, transactionContext, exception);
+        }
+    }
+}

--- a/Rebus/Retry/CircuitBreaker/CircuitBreakerSettings.cs
+++ b/Rebus/Retry/CircuitBreaker/CircuitBreakerSettings.cs
@@ -1,0 +1,50 @@
+﻿using System;
+
+namespace Rebus.Retry.CircuitBreaker
+{
+    /// <summary>
+    /// Contains the settings used by <see cref="CircuitBreakerSettings"/>
+    /// </summary>
+    public class CircuitBreakerSettings
+    {
+        /// <summary>
+        /// Default Attempts a circuit breaker will fail within a given <see cref="TrackingPeriod"/>
+        /// </summary>
+        public const int DefaultAttempts = 5;
+
+        /// <summary>
+        /// Default period where in errors are getting tracked
+        /// </summary>
+        public const int DefaultTrackingPeriodInSeconds = 30;
+
+        /// <summary>
+        /// Defailt time Interval for when the circuit breaker will close after being opened 
+        /// </summary>
+        public const int DefaultResetIntervalInSeconds = 300;
+
+        /// <summary>
+        /// Number of attempts that the circuit breaker will fail within a given <see cref="TrackingPeriod"/>
+        /// </summary>
+        public int Attempts { get; private set; }
+
+        /// <summary>
+        /// Time window wherein consecutive errors are getting tracked
+        /// </summary>
+        public TimeSpan TrackingPeriod { get; private set; }
+
+        /// <summary>
+        /// Time Interval for when the circuit breaker will close after being opened
+        /// </summary>
+        public TimeSpan ResetInterval { get; private set; }
+
+        /// <summary>
+        /// Create a setting for a given circuit breaker
+        /// </summary>
+        public CircuitBreakerSettings(int attempts, int trackingPeriodInSeconds, int resetIntervalInSeconds)
+        {
+            Attempts = attempts;
+            TrackingPeriod = TimeSpan.FromSeconds(trackingPeriodInSeconds);
+            ResetInterval = TimeSpan.FromSeconds(resetIntervalInSeconds);
+        }
+    }
+}

--- a/Rebus/Retry/CircuitBreaker/CircuitBreakerState.cs
+++ b/Rebus/Retry/CircuitBreaker/CircuitBreakerState.cs
@@ -1,9 +1,24 @@
 ﻿namespace Rebus.Retry.CircuitBreaker
 {
-    internal enum CircuitBreakerState
+    /// <summary>
+    /// Describes the state of the circuit breaker
+    /// </summary>
+    public enum CircuitBreakerState
     {
+        /// <summary>
+        /// State describing that the circuit is <see cref="Closed"/>, meaning that Rebus is working at the configured set of workers
+        /// </summary>
         Closed = 0,
+
+        /// <summary>
+        /// State describing that the circuit is <see cref="HalfOpen"/>, meaning that Rebus is working at a reduced set of workers
+        /// </summary>
         HalfOpen = 1,
+
+        /// <summary>
+        /// State describing that the circuit is <see cref="Open"/>, meaning that Rebus has reduced the number of workers until the faulty 
+        /// circuit breaker is reset
+        /// </summary>
         Open = 2
     }
 }

--- a/Rebus/Retry/CircuitBreaker/CircuitBreakerState.cs
+++ b/Rebus/Retry/CircuitBreaker/CircuitBreakerState.cs
@@ -1,0 +1,9 @@
+﻿namespace Rebus.Retry.CircuitBreaker
+{
+    internal enum CircuitBreakerState
+    {
+        Closed = 0,
+        HalfOpen = 1,
+        Open = 2
+    }
+}

--- a/Rebus/Retry/CircuitBreaker/ExceptionTypeCircuitBreaker.cs
+++ b/Rebus/Retry/CircuitBreaker/ExceptionTypeCircuitBreaker.cs
@@ -1,0 +1,94 @@
+﻿using Rebus.Time;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Rebus.Retry.CircuitBreaker
+{
+
+    internal class ExceptionTypeCircuitBreaker : ICircuitBreaker
+    {
+        private readonly Type exceptionType;
+        private readonly CircuitBreakerSettings settings;
+        private readonly IRebusTime rebusTime;
+        private ConcurrentDictionary<long, DateTimeOffset> _errorDates;
+
+        public ExceptionTypeCircuitBreaker(Type exceptionType
+            , CircuitBreakerSettings settings
+            , IRebusTime rebusTime)
+        {
+            this.exceptionType = exceptionType ?? throw new ArgumentNullException(nameof(exceptionType));
+            this.settings = settings ?? throw new ArgumentNullException(nameof(settings));
+            this.rebusTime = rebusTime;
+            State = CircuitBreakerState.Closed;
+
+            _errorDates = new ConcurrentDictionary<long, DateTimeOffset>();
+        }
+
+        public CircuitBreakerState State { get; private set; }
+
+        public bool IsClosed => State == CircuitBreakerState.Closed;
+
+        public bool IsHalfOpen => State == CircuitBreakerState.HalfOpen;
+
+        public bool IsOpen => State == CircuitBreakerState.Open;
+
+        public void Trip(Exception exception)
+        {
+            if (ShouldTripCircuitBreaker(exception) == false)
+                return;
+
+            var timeStamp = rebusTime.Now;
+            _errorDates.TryAdd(timeStamp.Ticks, timeStamp);
+
+            var errorsInPeriod = _errorDates
+                .Where(x => x.Key > timeStamp.Ticks - settings.TrackingPeriod.Ticks)
+                .Take(settings.Attempts);
+
+            // Do the tripping
+            if (errorsInPeriod.Count() >= settings.Attempts)
+            {
+                State = CircuitBreakerState.Open;
+            }
+
+            RemoveOutOfPeriodErrors(errorsInPeriod);
+        }
+
+        private bool ShouldTripCircuitBreaker(Exception exception)
+        {
+            if (exception is AggregateException e)
+            {
+                var actualException = e.InnerExceptions.First();
+                if (actualException.GetType().Equals(exceptionType))
+                    return true;
+            }
+
+            if (exception.GetType().Equals(exceptionType))
+                return true;
+
+            return false;
+        }
+
+        private void RemoveOutOfPeriodErrors(IEnumerable<KeyValuePair<long, DateTimeOffset>> tripsInPeriod)
+        {
+            var outDatedTimeStamps = _errorDates
+                .Except(tripsInPeriod)
+                .ToList();
+
+            foreach(var outDatedTimeStamp in outDatedTimeStamps) 
+                _errorDates.TryRemove(outDatedTimeStamp.Key, out _);
+        }
+
+        public async Task TryReset()
+        {
+
+
+            await Task.FromResult(0);
+
+            // Missing .net 4.5 compatibility 
+            // await Task.CompletedTask;
+        }
+    }
+} 

--- a/Rebus/Retry/CircuitBreaker/ExceptionTypeCircuitBreaker.cs
+++ b/Rebus/Retry/CircuitBreaker/ExceptionTypeCircuitBreaker.cs
@@ -84,11 +84,10 @@ namespace Rebus.Retry.CircuitBreaker
         public async Task Reset()
         {
 
-
-            await Task.FromResult(0);
-
             // Missing .net 4.5 compatibility 
             // await Task.CompletedTask;
+            await Task.FromResult(0);
+
         }
     }
 } 

--- a/Rebus/Retry/CircuitBreaker/ExceptionTypeCircuitBreaker.cs
+++ b/Rebus/Retry/CircuitBreaker/ExceptionTypeCircuitBreaker.cs
@@ -81,7 +81,7 @@ namespace Rebus.Retry.CircuitBreaker
                 _errorDates.TryRemove(outDatedTimeStamp.Key, out _);
         }
 
-        public async Task TryReset()
+        public async Task Reset()
         {
 
 

--- a/Rebus/Retry/CircuitBreaker/ICircuitBreaker.cs
+++ b/Rebus/Retry/CircuitBreaker/ICircuitBreaker.cs
@@ -11,6 +11,6 @@ namespace Rebus.Retry.CircuitBreaker
         bool IsOpen { get; }
         void Trip(Exception exception);
 
-        Task TryReset();
+        Task Reset();
     }
 }

--- a/Rebus/Retry/CircuitBreaker/ICircuitBreaker.cs
+++ b/Rebus/Retry/CircuitBreaker/ICircuitBreaker.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Rebus.Retry.CircuitBreaker
+{
+    internal interface ICircuitBreaker
+    {
+        CircuitBreakerState State { get; }
+        bool IsClosed { get; }
+        bool IsHalfOpen { get; }
+        bool IsOpen { get; }
+        void Trip(Exception exception);
+
+        Task TryReset();
+    }
+}

--- a/Rebus/Retry/CircuitBreaker/MainCircuitBreaker.cs
+++ b/Rebus/Retry/CircuitBreaker/MainCircuitBreaker.cs
@@ -36,7 +36,7 @@ namespace Rebus.Retry.CircuitBreaker
 
             _resetCircuitBreakerTask = asyncTaskFactory.Create(
                 BackgroundTaskName
-                , TryReset
+                , Reset
                 , prettyInsignificant: false
                 , intervalSeconds: 5);
         }
@@ -88,10 +88,10 @@ namespace Rebus.Retry.CircuitBreaker
             }
         }
 
-        public async Task TryReset()
+        public async Task Reset()
         {
             foreach (var circuitBreaker in _circuitBreakers)
-                await circuitBreaker.TryReset();
+                await circuitBreaker.Reset();
         }
 
         public void Initialize()

--- a/Rebus/Retry/CircuitBreaker/MainCircuitBreaker.cs
+++ b/Rebus/Retry/CircuitBreaker/MainCircuitBreaker.cs
@@ -1,0 +1,84 @@
+﻿using Rebus.Bus;
+using Rebus.Logging;
+using Rebus.Threading;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Rebus.Retry.CircuitBreaker
+{
+    internal class MainCircuitBreaker : ICircuitBreaker
+    {
+        const string BackgroundTaskName = "CircuitBreakersResetTimer";
+
+        readonly IAsyncTask _resetCircuitBreakerTask;
+
+        readonly IList<ICircuitBreaker> _circuitBreakers;
+        readonly RebusBus _rebusBus;
+        readonly ILog _log;
+
+        public MainCircuitBreaker(IList<ICircuitBreaker> circuitBreakers
+            , IRebusLoggerFactory rebusLoggerFactory
+            , IAsyncTaskFactory asyncTaskFactory
+            , RebusBus rebusBus)
+        {
+            _circuitBreakers = circuitBreakers ?? throw new ArgumentNullException(nameof(circuitBreakers));
+            _rebusBus = rebusBus;
+            _log = rebusLoggerFactory?.GetLogger<MainCircuitBreaker>() ?? throw new ArgumentNullException(nameof(rebusLoggerFactory));
+
+            _resetCircuitBreakerTask = asyncTaskFactory.Create(
+                BackgroundTaskName
+                , TryReset
+                , prettyInsignificant: false
+                , intervalSeconds: 5);
+        }
+
+        public CircuitBreakerState State => _circuitBreakers.Aggregate(CircuitBreakerState.Closed, (currentState, incomming) =>
+        {
+            if (incomming.State > currentState)
+                return incomming.State;
+
+            return currentState;
+        });
+
+        public bool IsClosed => _circuitBreakers.All(x => x.State == CircuitBreakerState.Closed);
+
+        public bool IsHalfOpen => State == CircuitBreakerState.HalfOpen;
+
+        public bool IsOpen => State == CircuitBreakerState.Open;
+
+        public void Trip(Exception exception)
+        {
+            var previousState = State;
+
+            foreach (var circuitBreaker in _circuitBreakers)
+                circuitBreaker.Trip(exception);
+
+            if (previousState == State)
+                return;
+
+            // It Seems like state have changed?
+            // Fire event?
+
+            if (IsClosed)
+                return;
+
+            if (IsHalfOpen) 
+            {
+                // TODO: Pick a half open strategy
+            }
+
+            if (IsOpen)
+            {
+                _rebusBus.SetNumberOfWorkers(0);
+            }
+        }
+
+        public async Task TryReset()
+        {
+            foreach (var circuitBreaker in _circuitBreakers)
+                await circuitBreaker.TryReset();
+        }
+    }
+}


### PR DESCRIPTION
Hi Rebus Team,

The following PR is the first stab at implementing a circuit breaker feature described in #882. The feature is not entirely done, so I would love some help and feedback getting the last details in place.

My motivation for this is that, after the issue was mentioned we internally in our company had a couple of discussions on where this could be applied. We found some very interesting use-cases that could potentially save a ton of workload, clean-up and headaches. So without much consideration I went ahead and took the first stab at the feature and to see where i goes.

The idea is pretty simple, Based on a known exception Type, trip and trigger a circuit breaker. In a case where the circuit opens, we would `SetNumberOfWorkers(0)` to ensure that Rebus has stopped processing messages for the time being.

### Configuration
This is how i imagine how you would configure circuit breakers.
```cs
 var bus = Configure.With(...) 
     .Options(o => 
     { 
          o.EnableCircuitBreakers(c => c.OpenOn<MyExternalServiceException>(attempts: 5
                                                                       , trackingPeriodInSeconds: 10
                                                                       , resetIntervalInSeconds: 300)); 
     })
     .Start(); 
```

### Discussion points
#### ErrorHandler
The `IErrorHandler` is first triggered after a handler has failed 5 times, this means, that if we have a faulty service throwing an exception,  the service still getting taxed at least 5 times before we trip 1 attempt. 
If we configure circuit breaker to have 5 attempts within an interval, then the service will get taxed 25 times! 
**Question** is whether we should move this logic away from the `IErrorHandler` and into a `IIncomingStep`, to ensure that an external dependency  is taxed more than necessary?

#### Half-Open State
Circuit breaker patterns defines the concepts of half open. In case of Rebus i would believe that this transfers into changing the number of workers of Rebus. 

**Question** As for the ´MainCircuitBreaker´, it detects whether we are in a half open state. Is there a number of appropriate workers we want to set, or should this be a calculated value?

`ExceptionTypeCircuitBreaker` Responsibility is to keep track of the individual exceptions and when they occurred. For the time being it will only detect when to Open the circuit. In this case I feel a bit vague on what it means for the circuit breaker to be half open. I believe the Half open state should be set when the circuit has been Open, no errors occurred in the previous period, and no reset event has been set.
**Question** What does it mean for the `ExceptionTypeCircuitBreaker` to be Half-Open?

#### Resetting the circuit breakers
I would love to get some input on how we would do this? Does rebus have some background task support that can inspect the circuit breakers and see whether the need to be reset? I am all 👂 👂

Any and all feedback is of course welcome :raised_hands:

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
