### PR TITLE
IAsyncTaskFactory: use TimeSpan for interval

### DIFF
--- a/Rebus/Pipeline/Receive/HandleDeferredMessagesStep.cs
+++ b/Rebus/Pipeline/Receive/HandleDeferredMessagesStep.cs
@@ -48,10 +48,7 @@ This is done by checking if the incoming message has a '" + Headers.DeferredUnti
 
             _log = rebusLoggerFactory.GetLogger<HandleDeferredMessagesStep>();
 
-            var dueTimeoutsPollIntervalSeconds = (int)options.DueTimeoutsPollInterval.TotalSeconds;
-            var intervalToUse = dueTimeoutsPollIntervalSeconds >= 1 ? dueTimeoutsPollIntervalSeconds : 1;
-
-            _dueMessagesSenderBackgroundTask = asyncTaskFactory.Create(DueMessagesSenderTaskName, TimerElapsed, intervalSeconds: intervalToUse);
+            _dueMessagesSenderBackgroundTask = asyncTaskFactory.Create(DueMessagesSenderTaskName, TimerElapsed, interval: options.DueTimeoutsPollInterval);
         }
 
         /// <summary>

--- a/Rebus/Retry/ErrorTracking/InMemErrorTracker.cs
+++ b/Rebus/Retry/ErrorTracking/InMemErrorTracker.cs
@@ -50,7 +50,7 @@ namespace Rebus.Retry.ErrorTracking
             _cleanupOldTrackedErrorsTask = asyncTaskFactory.Create(
                 BackgroundTaskName,
                 CleanupOldTrackedErrors,
-                intervalSeconds: 10
+                interval: TimeSpan.FromSeconds(10)
             );
         }
 

--- a/Rebus/Threading/IAsyncTaskFactory.cs
+++ b/Rebus/Threading/IAsyncTaskFactory.cs
@@ -11,6 +11,6 @@ namespace Rebus.Threading
         /// <summary>
         /// Creates a new async task
         /// </summary>
-        IAsyncTask Create(string description, Func<Task> action, bool prettyInsignificant = false, int intervalSeconds = 10);
+        IAsyncTask Create(string description, Func<Task> action, bool prettyInsignificant = false, TimeSpan? interval = null);
     }
 }

--- a/Rebus/Threading/SystemThreadingTimer/SystemThreadingTimerAsyncTaskFactory.cs
+++ b/Rebus/Threading/SystemThreadingTimer/SystemThreadingTimerAsyncTaskFactory.cs
@@ -23,9 +23,12 @@ namespace Rebus.Threading.SystemThreadingTimer
         /// <summary>
         /// Creates a new async task
         /// </summary>
-        public IAsyncTask Create(string description, Func<Task> action, bool prettyInsignificant = false, int intervalSeconds = 10)
+        public IAsyncTask Create(string description, Func<Task> action, bool prettyInsignificant = false, TimeSpan? interval = null)
         {
-            return new SystemThreadingTimerAsyncTask(description, action, _rebusLoggerFactory, prettyInsignificant);
+            return new SystemThreadingTimerAsyncTask(description, action, _rebusLoggerFactory, prettyInsignificant)
+            {
+                Interval = interval ?? TimeSpan.FromSeconds(10)
+            };
         }
     }
 }

--- a/Rebus/Threading/TaskParallelLibrary/TplAsyncTaskFactory.cs
+++ b/Rebus/Threading/TaskParallelLibrary/TplAsyncTaskFactory.cs
@@ -22,11 +22,11 @@ namespace Rebus.Threading.TaskParallelLibrary
         /// <summary>
         /// Creates a new async task
         /// </summary>
-        public IAsyncTask Create(string description, Func<Task> action, bool prettyInsignificant = false, int intervalSeconds = 10)
+        public IAsyncTask Create(string description, Func<Task> action, bool prettyInsignificant = false, TimeSpan? interval = null)
         {
             return new TplAsyncTask(description, action, _rebusLoggerFactory, prettyInsignificant)
             {
-                Interval = TimeSpan.FromSeconds(intervalSeconds)
+                Interval = interval ?? TimeSpan.FromSeconds(10)
             };
         }
     }


### PR DESCRIPTION
Replace integer seconds parameter with `TimeSpan` avoiding unnecessary conversion between `TimeSpan` and `int` in `HandleDeferredMessagesStep`.

It also removes a strange behaviour in case of `DueTimeoutsPollInterval` is set with <0.5 `TotalSeconds`, that would cause to call `IAsyncTaskFactory` with intervalSeconds:0, thus clamped to `100ms` by Interval setter on `TplAsyncFactory`.

Also fix `SystemThreadingTimerAsyncTaskFactory` ignoring interval parameter.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
