### PR TITLE
Add UsedImplicitly annotation to IHandleMessages so implementations doesn't show up as unused. 

### DIFF
--- a/Rebus/Handlers/IHandleMessages.cs
+++ b/Rebus/Handlers/IHandleMessages.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using JetBrains.Annotations;
 
 namespace Rebus.Handlers
 {
@@ -10,6 +11,7 @@ namespace Rebus.Handlers
     /// <summary>
     /// Message handler interface. Implement this in order to get to handle messages of a specific type
     /// </summary>
+    [UsedImplicitly(ImplicitUseTargetFlags.Itself | ImplicitUseTargetFlags.WithInheritors)]
     public interface IHandleMessages<in TMessage> : IHandleMessages
     {
         /// <summary>

--- a/Rebus/Rebus.csproj
+++ b/Rebus/Rebus.csproj
@@ -65,6 +65,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net45|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
+    <PropertyGroup>
+        <DefineConstants>$(DefineConstants);JETBRAINS_ANNOTATIONS</DefineConstants>
+    </PropertyGroup>
   <ItemGroup Condition="'$(EnableSourceLink)' != 'false'">
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
@@ -74,6 +77,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="JetBrains.Annotations" Version="2020.3.0" PrivateAssets="all" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' OR '$(TargetFramework)' == 'net46'">


### PR DESCRIPTION
Implements and closes #914

This is the nuspec dotnet generates for the project now:

```xml
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
  <metadata>
    <id>Rebus</id>
    <version>1.0.3</version>
    <authors>mookid8000</authors>
    <requireLicenseAcceptance>false</requireLicenseAcceptance>
    <license type="expression">MIT</license>
    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
    <icon>little_rebusbus2_copy-500x500.png</icon>
    <projectUrl>https://rebus.fm/what-is-rebus/</projectUrl>
    <description>Rebus is a lean service bus for .NET</description>
    <copyright>Copyright 2012</copyright>
    <tags>rebus queue messaging service bus</tags>
    <repository type="git" url="https://github.com/rebus-org/Rebus" commit="25e85c1a38822da6567149aef575409af3fa121e" />
    <dependencies>
      <group targetFramework=".NETFramework4.5">
        <dependency id="Newtonsoft.Json" version="11.0.1" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETFramework4.6">
        <dependency id="Newtonsoft.Json" version="11.0.1" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard2.0">
        <dependency id="Microsoft.CSharp" version="4.5.0" exclude="Build,Analyzers" />
        <dependency id="Newtonsoft.Json" version="11.0.1" exclude="Build,Analyzers" />
        <dependency id="System.Dynamic.Runtime" version="4.3.0" exclude="Build,Analyzers" />
        <dependency id="System.Reflection.Emit.LightWeight" version="4.3.0" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard2.1">
        <dependency id="Microsoft.CSharp" version="4.5.0" exclude="Build,Analyzers" />
        <dependency id="Newtonsoft.Json" version="11.0.1" exclude="Build,Analyzers" />
        <dependency id="System.Dynamic.Runtime" version="4.3.0" exclude="Build,Analyzers" />
        <dependency id="System.Reflection.Emit.LightWeight" version="4.3.0" exclude="Build,Analyzers" />
      </group>
    </dependencies>
    <frameworkAssemblies>
      <frameworkAssembly assemblyName="Microsoft.CSharp" targetFramework=".NETFramework4.5, .NETFramework4.6" />
      <frameworkAssembly assemblyName="System.Configuration" targetFramework=".NETFramework4.5, .NETFramework4.6" />
      <frameworkAssembly assemblyName="System.Core" targetFramework=".NETFramework4.5, .NETFramework4.6" />
      <frameworkAssembly assemblyName="System" targetFramework=".NETFramework4.5, .NETFramework4.6" />
    </frameworkAssemblies>
  </metadata>
</package>
```
As you can see there is no reference to `JetBrains.Annotations`. End users still have to include JetBrains.Annotations in their project if they want to benefit, but at that point in time I also expect that they are fine with it, since they are free to choose. 

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
