### PR TITLE
Add support for mapping all types under a specific namespace in an assembly

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,21 @@ which will stuff the resulting `IBus` in the container as a singleton and use th
 message handlers. Check out the Configuration section on [the official Rebus documentation wiki][REBUS_WIKI] for
 more information on how to do this.
 
+If you want to be more specific about what types you map in an assembly, such as if the assembly is shared with other code you can map all the types under a specific namespace like this:
+
+```csharp
+Configure.With(someContainerAdapter)
+    .(...)
+    .Routing(r => r.TypeBased().MapAssemblyNamespaceOf<SomeMessageType>("namespaceInputQueue"))
+    .(...);
+
+// have IBus injected in application services for the duration of the application lifetime    
+
+// let the container dispose the bus when your application exits
+myFavoriteIocContainer.Dispose();
+```
+
+
 License
 ====
 

--- a/Rebus.Tests/Routing/TestTypeBasedRouter.cs
+++ b/Rebus.Tests/Routing/TestTypeBasedRouter.cs
@@ -63,7 +63,7 @@ namespace Rebus.Tests.Routing
         }
 
         [Test]
-        public void WorksWithMultipleRoutes ()
+        public void WorksWithMultipleRoutes()
         {
             _router
                 .Map<string>("StringDestination")
@@ -73,6 +73,35 @@ namespace Rebus.Tests.Routing
             Assert.That(GetDestinationForBody("STRING BODY"), Is.EqualTo("StringDestination"));
             Assert.That(GetDestinationForBody(DateTime.Now), Is.EqualTo("DateTimeDestination"));
             Assert.That(GetDestinationForBody(78), Is.EqualTo("IntDestination"));
+        }
+
+        [Test]
+        public void WorksWithAssemblyRouteMapping()
+        {
+            _router.MapAssemblyOf<TestNamespaceRouting.AssemblyMessageOne>("AssemblyDestination");
+
+            // All these should be mapped from the entire assembly (along with a ton more, but that's beside the point for this test)
+            Assert.That(GetDestinationForBody(new TestNamespaceRouting.AssemblyMessageOne()), Is.EqualTo("AssemblyDestination"));
+            Assert.That(GetDestinationForBody(new TestNamespaceRouting.AssemblyMessageTwo()), Is.EqualTo("AssemblyDestination"));
+            Assert.That(GetDestinationForBody(new TestNamespaceRouting.SubNamespace.AssemblyMessageSubNamespace()), Is.EqualTo("AssemblyDestination"));
+            Assert.That(GetDestinationForBody(new OtherNamespaceRouting.AssemblyMessageOtherNamespace()), Is.EqualTo("AssemblyDestination"));
+        }
+
+        [Test]
+        public void WorksWithNamespaceRouteMapping()
+        {
+            _router.MapAssemblyNamespaceOf<TestNamespaceRouting.AssemblyMessageOne>("AssemblyDestination");
+
+            // All these should be mapped from the namespace and sub-namespace
+            Assert.That(GetDestinationForBody(new TestNamespaceRouting.AssemblyMessageOne()), Is.EqualTo("AssemblyDestination"));
+            Assert.That(GetDestinationForBody(new TestNamespaceRouting.AssemblyMessageTwo()), Is.EqualTo("AssemblyDestination"));
+            Assert.That(GetDestinationForBody(new TestNamespaceRouting.SubNamespace.AssemblyMessageSubNamespace()), Is.EqualTo("AssemblyDestination"));
+
+            // This one should NOT be mapped
+            Assert.Throws<AggregateException>(() =>
+            {
+                GetDestinationForBody(new OtherNamespaceRouting.AssemblyMessageOtherNamespace());
+            });
         }
 
         [Test]
@@ -108,5 +137,32 @@ namespace Rebus.Tests.Routing
         }
 
         static Dictionary<string, string> NoHeaders => new Dictionary<string, string>();
+    }
+}
+
+// Set up some types we can use to test namespace mapping
+namespace Rebus.Tests.Routing.TestNamespaceRouting
+{
+    // Set up some types we can use to test assembly mapping
+    class AssemblyMessageOne
+    {
+    }
+
+    class AssemblyMessageTwo
+    {
+    }
+
+    namespace SubNamespace
+    {
+        class AssemblyMessageSubNamespace
+        {
+        }
+    }
+}
+
+namespace Rebus.Tests.Routing.OtherNamespaceRouting
+{
+    class AssemblyMessageOtherNamespace
+    {
     }
 }

--- a/Rebus.Tests/Routing/TestTypeBasedRouter.cs
+++ b/Rebus.Tests/Routing/TestTypeBasedRouter.cs
@@ -88,6 +88,26 @@ namespace Rebus.Tests.Routing
         }
 
         [Test]
+        public void WorksWithAssemblyRouteMappingAndDerivedClasses()
+        {
+            _router.MapAssemblyDerivedFrom<TestNamespaceRouting.AssemblyMessageBaseClass>("AssemblyDestination");
+
+            // All these should be mapped from the entire assembly (along with a ton more, but that's beside the point for this test)
+            Assert.That(GetDestinationForBody(new TestNamespaceRouting.AssemblyMessageOne()), Is.EqualTo("AssemblyDestination"));
+            Assert.That(GetDestinationForBody(new TestNamespaceRouting.SubNamespace.AssemblyMessageSubNamespace()), Is.EqualTo("AssemblyDestination"));
+
+            // These ones should NOT be mapped
+            Assert.Throws<AggregateException>(() =>
+            {
+                GetDestinationForBody(new TestNamespaceRouting.AssemblyMessageTwo());
+            });
+            Assert.Throws<AggregateException>(() =>
+            {
+                GetDestinationForBody(new OtherNamespaceRouting.AssemblyMessageOtherNamespace());
+            });
+        }
+
+        [Test]
         public void WorksWithNamespaceRouteMapping()
         {
             _router.MapAssemblyNamespaceOf<TestNamespaceRouting.AssemblyMessageOne>("AssemblyDestination");
@@ -143,8 +163,11 @@ namespace Rebus.Tests.Routing
 // Set up some types we can use to test namespace mapping
 namespace Rebus.Tests.Routing.TestNamespaceRouting
 {
-    // Set up some types we can use to test assembly mapping
-    class AssemblyMessageOne
+    class AssemblyMessageBaseClass
+    {
+    }
+
+    class AssemblyMessageOne : AssemblyMessageBaseClass
     {
     }
 
@@ -154,7 +177,7 @@ namespace Rebus.Tests.Routing.TestNamespaceRouting
 
     namespace SubNamespace
     {
-        class AssemblyMessageSubNamespace
+        class AssemblyMessageSubNamespace : AssemblyMessageBaseClass
         {
         }
     }

--- a/Rebus/Routing/TypeBased/TypeBasedRouter.cs
+++ b/Rebus/Routing/TypeBased/TypeBasedRouter.cs
@@ -50,13 +50,39 @@ namespace Rebus.Routing.TypeBased
         }
 
         /// <summary>
+        /// Maps <paramref name="destinationAddress"/> as the owner of all message types found in the same assembly as <typeparamref name="TDerivedFrom"/>
+        /// and derived from <typeparamref name="TDerivedFrom"/>
+        /// </summary>
+        public TypeBasedRouter MapAssemblyDerivedFrom<TDerivedFrom>(string destinationAddress)
+        {
+            MapAssemblyDerivedFrom(typeof(TDerivedFrom), destinationAddress);
+            return this;
+        }
+
+        /// <summary>
+        /// Maps <paramref name="destinationAddress"/> as the owner of all message types found in the same assembly as <paramref name="derivedFrom"/>
+        /// and optionally derived from <paramref name="derivedFrom"/>
+        /// </summary>
+        public TypeBasedRouter MapAssemblyDerivedFrom(Type derivedFrom, string destinationAddress)
+        {
+            foreach (var typeToMap in derivedFrom.GetTypeInfo().Assembly.GetTypes().Where(t => t.IsClass))
+            {
+                if (derivedFrom == null || typeToMap != derivedFrom && derivedFrom.IsAssignableFrom(typeToMap))
+                {
+                    SaveMapping(typeToMap, destinationAddress);
+                }
+            }
+            return this;
+        }
+
+        /// <summary>
         /// Maps <paramref name="destinationAddress"/> as the owner of all message types found in the same assembly as <typeparamref name="TMessage"/> under
         /// the namespace that type lives under. So all types within the same namespace will get mapped to that destination address, but not types under
         /// other namespaces. This allows you to separate messages for specific queues by namespace and register them all in one go.
         /// </summary>
         public TypeBasedRouter MapAssemblyNamespaceOf<TMessage>(string destinationAddress)
         {
-            MapAssemblyNamespaceOf(typeof (TMessage), destinationAddress);
+            MapAssemblyNamespaceOf(typeof(TMessage), destinationAddress);
             return this;
         }
 
@@ -70,6 +96,36 @@ namespace Rebus.Routing.TypeBased
             foreach (var typeToMap in messageType.GetTypeInfo().Assembly.GetTypes().Where(t => t.IsClass && t.Namespace != null && t.Namespace.StartsWith(messageType.Namespace ?? string.Empty)))
             {
                 SaveMapping(typeToMap, destinationAddress);
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Maps <paramref name="destinationAddress"/> as the owner of all message types found in the same assembly as <typeparamref name="TMessage"/> under
+        /// the namespace that type lives under and derived from <typeparamref name="TDerivedFrom"/>. So all types within the same namespace will
+        /// get mapped to that destination address, but not types under other namespaces. This allows you to separate messages for specific queues by
+        /// namespace and register them all in one go.
+        /// </summary>
+        public TypeBasedRouter MapAssemblyNamespaceOfDerivedFrom<TMessage, TDerivedFrom>(string destinationAddress)
+        {
+            MapAssemblyNamespaceOfDerivedFrom(typeof(TMessage), typeof(TDerivedFrom), destinationAddress);
+            return this;
+        }
+
+        /// <summary>
+        /// Maps <paramref name="destinationAddress"/> as the owner of all message types found in the same assembly as <paramref name="messageType"/> under
+        /// the namespace that type lives under and derived from <paramref name="derivedFrom"/>. So all types within the same namespace will
+        /// get mapped to that destination address, but not types under other namespaces. This allows you to separate messages for specific queues by
+        /// namespace and register them all in one go.
+        /// </summary>
+        public TypeBasedRouter MapAssemblyNamespaceOfDerivedFrom(Type messageType, Type derivedFrom, string destinationAddress)
+        {
+            foreach (var typeToMap in messageType.GetTypeInfo().Assembly.GetTypes().Where(t => t.IsClass && t.Namespace != null && t.Namespace.StartsWith(messageType.Namespace ?? string.Empty)))
+            {
+                if (derivedFrom == null || typeToMap != derivedFrom && derivedFrom.IsAssignableFrom(typeToMap))
+                {
+                    SaveMapping(typeToMap, destinationAddress);
+                }
             }
             return this;
         }

--- a/Rebus/Routing/TypeBased/TypeBasedRouterConfigurationExtensions.cs
+++ b/Rebus/Routing/TypeBased/TypeBasedRouterConfigurationExtensions.cs
@@ -72,6 +72,16 @@ namespace Rebus.Routing.TypeBased
             }
 
             /// <summary>
+            /// Maps <paramref name="destinationAddress"/> as the owner of all message types found in the same assembly as <typeparamref name="TDerivedFrom"/>
+            /// and derived from <typeparamref name="TDerivedFrom"/>
+            /// </summary>
+            public TypeBasedRouterConfigurationBuilder MapAssemblyDerivedFrom<TDerivedFrom>(string destinationAddress)
+            {
+                _configurationActions.Add(r => r.MapAssemblyDerivedFrom<TDerivedFrom>(destinationAddress));
+                return this;
+            }
+
+            /// <summary>
             /// Maps <paramref name="destinationAddress"/> as the owner of all message types found in the same assembly as <typeparamref name="TMessage"/> under
             /// the namespace that type lives under. So all types within the same namespace will get mapped to that destination address, but not types under
             /// other namespaces. This allows you to separate messages for specific queues by namespace and register them all in one go.
@@ -90,6 +100,28 @@ namespace Rebus.Routing.TypeBased
             public TypeBasedRouterConfigurationBuilder MapAssemblyNamespaceOf(Type messageType, string destinationAddress)
             {
                 _configurationActions.Add(r => r.MapAssemblyNamespaceOf(messageType, destinationAddress));
+                return this;
+            }
+
+            /// <summary>
+            /// Maps <paramref name="destinationAddress"/> as the owner of all message types found in the same assembly as <typeparamref name="TMessage"/> under
+            /// the namespace that type lives under. So all types within the same namespace will get mapped to that destination address, but not types under
+            /// other namespaces. This allows you to separate messages for specific queues by namespace and register them all in one go.
+            /// </summary>
+            public TypeBasedRouterConfigurationBuilder MapAssemblyNamespaceOfDerivedFrom<TMessage, TDerivedFrom>(string destinationAddress)
+            {
+                _configurationActions.Add(r => r.MapAssemblyNamespaceOfDerivedFrom<TMessage, TDerivedFrom>(destinationAddress));
+                return this;
+            }
+
+            /// <summary>
+            /// Maps <paramref name="destinationAddress"/> as the owner of all message types found in the same assembly as <paramref name="messageType"/> under
+            /// the namespace that type lives under. So all types within the same namespace will get mapped to that destination address, but not types under
+            /// other namespaces. This allows you to separate messages for specific queues by namespace and register them all in one go.
+            /// </summary>
+            public TypeBasedRouterConfigurationBuilder MapAssemblyNamespaceOfDerivedFrom(Type messageType, Type derivedFrom, string destinationAddress)
+            {
+                _configurationActions.Add(r => r.MapAssemblyNamespaceOfDerivedFrom(messageType, derivedFrom, destinationAddress));
                 return this;
             }
 

--- a/Rebus/Routing/TypeBased/TypeBasedRouterConfigurationExtensions.cs
+++ b/Rebus/Routing/TypeBased/TypeBasedRouterConfigurationExtensions.cs
@@ -63,6 +63,37 @@ namespace Rebus.Routing.TypeBased
             }
 
             /// <summary>
+            /// Maps <paramref name="destinationAddress"/> as the owner of all message types found in the same assembly as <paramref name="messageType"/>
+            /// </summary>
+            public TypeBasedRouterConfigurationBuilder MapAssemblyOf(Type messageType, string destinationAddress)
+            {
+                _configurationActions.Add(r => r.MapAssemblyOf(messageType, destinationAddress));
+                return this;
+            }
+
+            /// <summary>
+            /// Maps <paramref name="destinationAddress"/> as the owner of all message types found in the same assembly as <typeparamref name="TMessage"/> under
+            /// the namespace that type lives under. So all types within the same namespace will get mapped to that destination address, but not types under
+            /// other namespaces. This allows you to separate messages for specific queues by namespace and register them all in one go.
+            /// </summary>
+            public TypeBasedRouterConfigurationBuilder MapAssemblyNamespaceOf<TMessage>(string destinationAddress)
+            {
+                _configurationActions.Add(r => r.MapAssemblyNamespaceOf<TMessage>(destinationAddress));
+                return this;
+            }
+
+            /// <summary>
+            /// Maps <paramref name="destinationAddress"/> as the owner of all message types found in the same assembly as <paramref name="messageType"/> under
+            /// the namespace that type lives under. So all types within the same namespace will get mapped to that destination address, but not types under
+            /// other namespaces. This allows you to separate messages for specific queues by namespace and register them all in one go.
+            /// </summary>
+            public TypeBasedRouterConfigurationBuilder MapAssemblyNamespaceOf(Type messageType, string destinationAddress)
+            {
+                _configurationActions.Add(r => r.MapAssemblyNamespaceOf(messageType, destinationAddress));
+                return this;
+            }
+
+            /// <summary>
             /// Maps <paramref name="destinationAddress"/> as a fallback destination to use when none of the configured mappings match
             /// </summary>
             public TypeBasedRouterConfigurationBuilder MapFallback(string destinationAddress)


### PR DESCRIPTION
Make sure to only map classes for message types when doing assembly mapping, and added support for mapping all types under a namespace within an assembly.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
