### PR TITLE
Add support for bailing from a failed message handler 

### DIFF
--- a/Rebus/Retry/Simple/SimpleRetryStrategyStep.cs
+++ b/Rebus/Retry/Simple/SimpleRetryStrategyStep.cs
@@ -138,7 +138,10 @@ If the maximum number of delivery attempts is reached, the message is moved to t
             }
             catch (Exception exception)
             {
-                _errorTracker.RegisterError(identifierToTrackMessageBy, exception);
+                if (secondLevelMessageId == null || !(exception is FailFastException))
+                {
+                    _errorTracker.RegisterError(identifierToTrackMessageBy, exception);
+                }
 
                 transactionContext.Abort();
             }


### PR DESCRIPTION
In order to allow a failed message handler to abort and punt the message to the poison queue, if we throw a FailFastException that also ends up in the exception log for the message in the poison queue, which is annoying. This patch will no log any FailFastException's in second level retry handlers to avoid that. Used like this:

```C#
    var deferCount = CM.ToInt(message.Headers.GetValueOrDefault(Headers.DeferCount));
    if (deferCount >= 3) {
        throw new FailFastException("Too many errors!");
    }
    await Bus.Advanced.TransportMessage.Defer(TimeSpan.FromSeconds(5));
```

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
