### PR TITLE
Centralized the filesystem writeability checks

### DIFF
--- a/Rebus/DataBus/FileSystem/FileSystemDataBusStorage.cs
+++ b/Rebus/DataBus/FileSystem/FileSystemDataBusStorage.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Rebus.Bus;
 using Rebus.Exceptions;
 using Rebus.Logging;
+using Rebus.Persistence.FileSystem;
 using Rebus.Serialization;
 using Rebus.Time;
 // ReSharper disable UnusedVariable
@@ -56,7 +57,7 @@ namespace Rebus.DataBus.FileSystem
             }
 
             _log.Info("Checking that the current process has read/write access to directory {directoryPath}", _directoryPath);
-            EnsureDirectoryIsWritable();
+            FileSystemHelpers.EnsureDirectoryIsWritable(_directoryPath);
         }
 
         /// <summary>
@@ -255,37 +256,6 @@ namespace Rebus.DataBus.FileSystem
             catch (Exception exception)
             {
                 throw new RebusApplicationException(exception, $"Could not read metadata for data with ID {id}");
-            }
-        }
-
-        void EnsureDirectoryIsWritable()
-        {
-            var now = DateTime.Now;
-            var filePath = Path.Combine(_directoryPath, $"write-test-{Guid.NewGuid()}-DELETE-ME.tmp");
-
-            try
-            {
-                const string contents =
-                    @"Wrote this file to be sure that this Rebus endpoint has read/write access to this directory.
-
-This file can be safely deleted.";
-
-                File.WriteAllText(filePath, contents, Encoding.UTF8);
-
-                File.ReadAllText(filePath, Encoding.UTF8);
-
-            }
-            catch (Exception exception)
-            {
-                throw new IOException($"Write/Read test failed for directory path '{_directoryPath}'", exception);
-            }
-            finally
-            {
-                try
-                {
-                    File.Delete(filePath);
-                }
-                catch { }
             }
         }
     }

--- a/Rebus/Persistence/FileSystem/FileSystemSagaSnapshotStorage.cs
+++ b/Rebus/Persistence/FileSystem/FileSystemSagaSnapshotStorage.cs
@@ -37,35 +37,14 @@ namespace Rebus.Persistence.FileSystem
         /// </summary>
         public void Initialize()
         {
-            if (Directory.Exists(_snapshotDirectory)) return;
-
-            _log.Info("Saga snapshot directory {directoryPath} does not exist - creating it!", _snapshotDirectory);
-
-            Directory.CreateDirectory(_snapshotDirectory);
-
-            var writabilityCheckFilePath = Path.Combine(_snapshotDirectory, "rebus.writability.check.txt");
-
-            try
+            if (!Directory.Exists(_snapshotDirectory))
             {
-                File.WriteAllText(writabilityCheckFilePath, "RBS2!1");
+                _log.Info("Saga snapshot directory {directoryPath} does not exist - creating it!", _snapshotDirectory);
+                Directory.CreateDirectory(_snapshotDirectory);
             }
-            catch (Exception exception)
-            {
-                var message = $"Could not write dummy file to saga snapshot directory '{_snapshotDirectory}' - is it writable for the {Environment.UserDomainName} / {Environment.UserName} account?";
 
-                throw new IOException(message, exception);
-            }
-            finally
-            {
-                try
-                {
-                    File.Delete(writabilityCheckFilePath);
-                }
-                catch
-                {
-                    // ignored
-                }
-            }
+            _log.Info("Checking that the current process has read/write access to directory {directoryPath}", _snapshotDirectory);
+            FileSystemHelpers.EnsureDirectoryIsWritable(_snapshotDirectory);
         }
 
         /// <summary>

--- a/Rebus/Persistence/FileSystem/FilesystemHelpers.cs
+++ b/Rebus/Persistence/FileSystem/FilesystemHelpers.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.IO;
+
+namespace Rebus.Persistence.FileSystem
+{
+    internal static class FileSystemHelpers
+    {
+        /// <summary>
+        /// Make sure the directory is writeable by the current process
+        /// </summary>
+        /// <param name="directoryPath">Directory path to check</param>
+        /// <exception cref="IOException">Exception thrown if directory cannot be written to</exception>
+        public static void EnsureDirectoryIsWritable(string directoryPath)
+        {
+            // Use a GUID to generate the filename, so we avoid multiple threads stomping on the same file
+            // during startup.
+            var filePath = Path.Combine(directoryPath, $"write-test-{Guid.NewGuid()}-DELETE-ME.tmp");
+
+            try
+            {
+                File.WriteAllText(filePath, "RBS2!1");
+                File.ReadAllText(filePath);
+            }
+            catch (Exception exception)
+            {
+                var message = $"Write/Read test failed for directory path '{directoryPath}' - is it writable for the {Environment.UserDomainName} / {Environment.UserName} account?";
+                throw new IOException(message, exception);
+            }
+            finally
+            {
+                try
+                {
+                    File.Delete(filePath);
+                }
+                catch
+                {
+                    // ignored
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Centralized the filesystem writeability checks to use the same code for both databus and saga snapshots. Did not change anything related to other filesystem code like transport, since it was not currently doing that.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
