### PR TITLE
Need a way for the exclusive saga lock instance to be pulled from injectionist

### DIFF
--- a/Rebus.Tests/Assumptions/TestLockContention.cs
+++ b/Rebus.Tests/Assumptions/TestLockContention.cs
@@ -81,15 +81,14 @@ Elapsed: {elapsed.TotalSeconds:0.0}
         static IEnumerable<IIncomingStep> GetSteps()
         {
             var handler = new ConcurrentDictionaryExclusiveSagaAccessLock();
-            yield return new EnforceExclusiveSagaAccessIncomingStep(handler, CancellationToken.None);
+            yield return new EnforceExclusiveSagaAccessIncomingStep(handler, 10, CancellationToken.None);
             yield return new NewEnforceExclusiveSagaAccessIncomingStep(10, CancellationToken.None);
-            yield return new EnforceExclusiveSagaAccessIncomingStep(handler, CancellationToken.None);
+            yield return new EnforceExclusiveSagaAccessIncomingStep(handler, 20, CancellationToken.None);
             yield return new NewEnforceExclusiveSagaAccessIncomingStep(20, CancellationToken.None);
-            yield return new EnforceExclusiveSagaAccessIncomingStep(handler, CancellationToken.None);
+            yield return new EnforceExclusiveSagaAccessIncomingStep(handler, 50, CancellationToken.None);
             yield return new NewEnforceExclusiveSagaAccessIncomingStep(50, CancellationToken.None);
-            yield return new EnforceExclusiveSagaAccessIncomingStep(handler, CancellationToken.None);
+            yield return new EnforceExclusiveSagaAccessIncomingStep(handler, 100, CancellationToken.None);
             yield return new NewEnforceExclusiveSagaAccessIncomingStep(100, CancellationToken.None);
         }
     }
-
 }

--- a/Rebus.Tests/Sagas/TestSagaInstanceLocking_Custom.cs
+++ b/Rebus.Tests/Sagas/TestSagaInstanceLocking_Custom.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -152,13 +151,13 @@ namespace Rebus.Tests.Sagas
         {
             readonly SemaphoreSlim _mutex = new SemaphoreSlim(initialCount: 1, maxCount: 1);
 
-            public async Task<bool> AquireLockAsync(string key, CancellationToken cancellationToken)
+            public async Task<bool> AquireLockAsync(int key, CancellationToken cancellationToken)
             {
                 await _mutex.WaitAsync(cancellationToken);
                 return true;
             }
 
-            public async Task<bool> ReleaseLockAsync(string key)
+            public async Task<bool> ReleaseLockAsync(int key)
             {
                 _mutex.Release();
                 return true;

--- a/Rebus/Sagas/Exclusive/ConcurrentDictionaryExclusiveSagaAccessLock.cs
+++ b/Rebus/Sagas/Exclusive/ConcurrentDictionaryExclusiveSagaAccessLock.cs
@@ -9,15 +9,13 @@ namespace Rebus.Sagas.Exclusive
     /// </summary>
     class ConcurrentDictionaryExclusiveSagaAccessLock : IExclusiveSagaAccessLock
     {
-        const string DummyValue = "dummy";
-        
         static readonly Task<bool> TrueResult = Task.FromResult(true);
         static readonly Task<bool> FalseResult = Task.FromResult(false);
 
-        readonly ConcurrentDictionary<string, string> _locks = new ConcurrentDictionary<string, string>();
+        readonly ConcurrentDictionary<int, byte> _locks = new ConcurrentDictionary<int, byte>();
 
-        public Task<bool> AquireLockAsync(string key, CancellationToken cancellationToken) => _locks.TryAdd(key, DummyValue) ? TrueResult : FalseResult;
+        public Task<bool> AquireLockAsync(int key, CancellationToken cancellationToken) => _locks.TryAdd(key, 1) ? TrueResult : FalseResult;
 
-        public Task<bool> ReleaseLockAsync(string key) => _locks.TryRemove(key, out var dummy) ? TrueResult : FalseResult;
+        public Task<bool> ReleaseLockAsync(int key) => _locks.TryRemove(key, out var dummy) ? TrueResult : FalseResult;
     }
 }

--- a/Rebus/Sagas/Exclusive/IExclusiveLock.cs
+++ b/Rebus/Sagas/Exclusive/IExclusiveLock.cs
@@ -1,0 +1,34 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace Rebus.Sagas.Exclusive
+{
+    /// <summary>
+    /// Defines API for generic exclusive locks
+    /// </summary>
+    public interface IExclusiveLock
+    {
+        /// <summary>
+        /// Aquire a lock for given key
+        /// </summary>
+        /// <param name="key">Locking key</param>
+        /// <param name="cancellationToken">Cancellation token which will be cancelled if Rebus shuts down. Can be used if e.g. distributed locks have a timeout associated with them</param>
+        /// <returns>True if the lock was aquired, false if not</returns>
+        Task<bool> AquireLockAsync(string key, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Determines if a lock has been aquired or not
+        /// </summary>
+        /// <param name="key">Locking key</param>
+        /// <param name="cancellationToken">Cancellation token which will be cancelled if Rebus shuts down. Can be used if e.g. distributed locks have a timeout associated with them</param>
+        /// <returns>True of the lock was aquired already, false if not</returns>
+        Task<bool> IsLockAquiredAsync(string key, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Release a lock for given key
+        /// </summary>
+        /// <param name="key">Locking key</param>
+        /// <returns>True of the lock was released, false if not</returns>
+        Task<bool> ReleaseLockAsync(string key);
+    }
+}

--- a/Rebus/Sagas/Exclusive/IExclusiveSagaAccessLock.cs
+++ b/Rebus/Sagas/Exclusive/IExclusiveSagaAccessLock.cs
@@ -4,23 +4,23 @@ using System.Threading.Tasks;
 namespace Rebus.Sagas.Exclusive
 {
     /// <summary>
-    /// Defines API for storing sagalocks
+    /// Defines API for storing saga locks
     /// </summary>
     public interface IExclusiveSagaAccessLock
     {
         /// <summary>
         /// Aquire a lock for given key
         /// </summary>
-        /// <param name="key">Lockingkey</param>
+        /// <param name="key">Locking key</param>
         /// <param name="cancellationToken">Cancellation token which will be cancelled if Rebus shuts down. Can be used if e.g. distributed locks have a timeout associated with them</param>
-        /// <returns></returns>
-        Task<bool> AquireLockAsync(string key, CancellationToken cancellationToken);
-        
+        /// <returns>True if the lock was aquired, false if not</returns>
+        Task<bool> AquireLockAsync(int key, CancellationToken cancellationToken);
+
         /// <summary>
         /// Release a lock for given key
         /// </summary>
-        /// <param name="key">Lockingkey</param>
-        /// <returns></returns>
-        Task<bool> ReleaseLockAsync(string key);
+        /// <param name="key">Locking key</param>
+        /// <returns>True if the lock was released, false if not</returns>
+        Task<bool> ReleaseLockAsync(int key);
     }
 }

--- a/Rebus6.sln.DotSettings
+++ b/Rebus6.sln.DotSettings
@@ -1,0 +1,3 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Aquire/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=aquired/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
Need a way for the exclusive saga lock instance to be pulled from injectionist so we can register it and have it's lifecycle managed.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
