### PR TITLE
feat(one-way): Configure.OneWayClient() with EmptyActivator

### DIFF
--- a/Rebus.Tests/Activation/OneWay.cs
+++ b/Rebus.Tests/Activation/OneWay.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Threading.Tasks;
+using Hypothesist;
+using Hypothesist.Rebus;
+using NUnit.Framework;
+using Rebus.Activation;
+using Rebus.Bus;
+using Rebus.Config;
+using Rebus.Persistence.InMem;
+using Rebus.Routing.TypeBased;
+using Rebus.Tests.Contracts;
+using Rebus.Transport.InMem;
+
+namespace Rebus.Tests.Activation;
+
+[TestFixture]
+public class ClientOnly : FixtureBase
+{
+    private record Message(Guid Id);
+
+    [Test]
+    public async Task ActivatorNotNecessary()
+    {
+        // Arrange
+        var message = new Message(Guid.NewGuid());
+        var hypothesis = Hypothesis.For<Message>()
+            .Any(m => m == message);
+
+        using var activator = new BuiltinHandlerActivator()
+            .Register(hypothesis.AsHandler);
+
+        var network = new InMemNetwork();
+        using var subscriber = await Subscriber(activator, network);
+        using var publisher = Publisher(network);
+
+        // Act
+        await publisher.Send(message); // publish doesn't work in this setup, not sure why
+
+        // Assert
+        await hypothesis.Validate(TimeSpan.FromSeconds(5));
+    }
+
+    private static IBus Publisher(InMemNetwork network) =>
+        Configure.OneWayClient()
+            .Transport(t => t.UseInMemoryTransportAsOneWayClient(network))
+            .Subscriptions(s => s.StoreInMemory()) // req'd also for one way client transports
+            .Routing(t => t.TypeBased().Map<Message>("subscriber"))
+            .Start();
+
+    private static async Task<IBus> Subscriber(IHandlerActivator activator, InMemNetwork network)
+    {
+        var subscriber = Configure.With(activator)
+            .Transport(t => t.UseInMemoryTransport(network, "subscriber"))
+            .Subscriptions(s => s.StoreInMemory())
+            .Routing(t => t.TypeBased().Map<Message>("not-sure")) // req'd also when only subscribing
+            .Start();
+
+        await subscriber.Subscribe<Message>();
+        return subscriber;
+    }
+}

--- a/Rebus.Tests/Rebus.Tests.csproj
+++ b/Rebus.Tests/Rebus.Tests.csproj
@@ -10,6 +10,7 @@
     <ProjectReference Include="..\Rebus.Tests.Contracts\Rebus.Tests.Contracts.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Hypothesist.Rebus" Version="2.0.30" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NUnit" Version="3.13.2" />

--- a/Rebus/Config/Configure.cs
+++ b/Rebus/Config/Configure.cs
@@ -34,4 +34,10 @@ or by registering a factory function like this:
 
         return new RebusConfigurer(handlerActivator);
     }
+
+    /// <summary>
+    /// Call this method when you're using one of the Transport(t => t.***AsOneWayClient()) transports and you don't have any <see cref="IHandlerActivator"/> to register.
+    /// </summary>
+    public static RebusConfigurer OneWayClient() => 
+        With(new EmptyActivator());
 }

--- a/Rebus/EmptyActivator.cs
+++ b/Rebus/EmptyActivator.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Rebus.Activation;
+using Rebus.Handlers;
+using Rebus.Transport;
+
+namespace Rebus;
+
+public class EmptyActivator : IHandlerActivator
+{
+    public Task<IEnumerable<IHandleMessages<TMessage>>> GetHandlers<TMessage>(TMessage message, ITransactionContext transactionContext) =>
+        Task.FromResult(Enumerable.Empty<IHandleMessages<TMessage>>());
+}


### PR DESCRIPTION
I slipt [Hypothesist](https://github.com/riezebosch/hypothesist/) in because of the easy integration testing, see #1014. For sure I'm open to rewriting it into `ManualResetEvent` or `TaskCompletionSource` if you'd prefer that.

I'm aware of the probably differentiating setup of the test but wasn't too sure how to fit it into the designated setup.

Fixes #1013.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
