### PR TITLE
Extensionpoint for fetching encryptionkeys

### DIFF
--- a/Rebus.Tests/Encryption/TestEncryptionKeyProviding.cs
+++ b/Rebus.Tests/Encryption/TestEncryptionKeyProviding.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Rebus.Encryption;
+
+namespace Rebus.Tests.Encryption;
+
+[TestFixture]
+public class TestEncryptionKeyProviding
+{
+    const string EncryptionKey = "UaVcj0zCA35mgrg9/pN62Rp+r629BMi9S9v0Tz4S7EM=";
+
+    [Test]
+    public async Task ProviderCanProvide()
+    {
+        var provider = new DefaultRijndaelEncryptionKeyProvider(EncryptionKey);
+        var provided = await provider.GetCurrentKey();
+        Assert.AreEqual(Convert.ToBase64String(provided.Key), EncryptionKey);
+        Assert.IsNotEmpty(provided.Identifier);
+
+        var specificProvided = await provider.GetSpecificKey(provided.Identifier);
+        Assert.AreEqual(Convert.ToBase64String(specificProvided.Key), EncryptionKey);
+        Assert.AreEqual(specificProvided.Identifier,provided.Identifier);
+    }
+
+    [Test]
+    public void ProviderOnlyToleratesValidKey()
+    {
+        Assert.Throws<ArgumentException>(() =>
+        {
+            // ReSharper disable once ObjectCreationAsStatement
+            new DefaultRijndaelEncryptionKeyProvider(EncryptionKey.Take(10).ToString());
+        });
+
+    }
+    
+    
+    
+}

--- a/Rebus/Encryption/DefaultRijndaelEncryptionKeyProvider.cs
+++ b/Rebus/Encryption/DefaultRijndaelEncryptionKeyProvider.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+
+namespace Rebus.Encryption;
+
+/// <summary>
+/// Helps with providing encryption keys for encrypting and decrypting messages.
+/// </summary>
+public class DefaultRijndaelEncryptionKeyProvider : IEncryptionKeyProvider
+{
+    private const string KeyIdentifier = "default";
+    private readonly EncryptionKey _encryptionKey;
+
+    /// <summary>
+    /// Creates the keyprovider with the specified key - the key must be a valid, base64-encoded key.
+    /// </summary>
+    /// <param name="encryptionKey"></param>
+    public DefaultRijndaelEncryptionKeyProvider(string encryptionKey)
+    {
+        try
+        {
+            _encryptionKey = new EncryptionKey(Convert.FromBase64String(encryptionKey), KeyIdentifier);
+
+            using var rijndael = new RijndaelManaged();
+            rijndael.Key = _encryptionKey.Key;
+        }
+        catch (Exception exception)
+        {
+            throw new ArgumentException(
+                $@"Could not initialize the encryption algorithm with the specified key (not shown here for security reasons) - if you're unsure how to get a valid key, here's a newly generated key that you can use:
+
+    {GenerateNewKey()}
+
+I promise that the suggested key has been generated this instant - if you don't believe me, feel free to run the program again ;)",
+                exception);
+        }
+    }
+
+    static string GenerateNewKey()
+    {
+        using var rijndael = new RijndaelManaged();
+
+        rijndael.GenerateKey();
+
+        return Convert.ToBase64String(rijndael.Key);
+    }
+
+    /// <summary>
+    /// Returns the key the provider was constructed with.
+    /// </summary>
+    /// <returns>An<see cref="EncryptionKey"/> containing the key and its identifier</returns>
+    public Task<EncryptionKey> GetCurrentKey()
+    {
+        return Task.FromResult(_encryptionKey);
+    }
+
+    /// <summary>
+    /// Returns a key matching the <see cref="identifier"/> if found.
+    /// </summary>
+    /// <param name="identifier">Identifier describing which key caller is asking for.</param>
+    /// <returns>An<see cref="EncryptionKey"/> containing the key and its identifier</returns>
+    /// <exception cref="ArgumentException">Throws if the provider has no key matching the specified <see cref="identifier"/></exception>.
+    public Task<EncryptionKey> GetSpecificKey(string identifier)
+    {
+        if (identifier != _encryptionKey.Identifier)
+            throw new ArgumentException(
+                $"The {nameof(DefaultRijndaelEncryptionKeyProvider)} only provides a single key with identifier {KeyIdentifier}");
+        return Task.FromResult(_encryptionKey);
+    }
+}

--- a/Rebus/Encryption/EncryptionConfigurationExtensions.cs
+++ b/Rebus/Encryption/EncryptionConfigurationExtensions.cs
@@ -29,7 +29,7 @@ public static class EncryptionConfigurationExtensions
     ///     .(...)
     ///     .Options(o => {
     ///         o.EnableCustomEncryption()
-    ///             .Use***();
+    ///             .Register(c => new MyCustomEncryptor());
     ///     })
     ///     .Start();
     /// </code>

--- a/Rebus/Encryption/EncryptionConfigurationExtensions.cs
+++ b/Rebus/Encryption/EncryptionConfigurationExtensions.cs
@@ -17,7 +17,7 @@ public static class EncryptionConfigurationExtensions
     /// </summary>
     public static void EnableEncryption(this OptionsConfigurer configurer, string key)
     {
-        EnableCustomEncryption(configurer).Register(c => new RijndaelEncryptor(key));
+        EnableCustomAsyncEncryption(configurer).Register(c => new RijndaelEncryptor(key));
     }
 
     /// <summary>
@@ -40,7 +40,7 @@ public static class EncryptionConfigurationExtensions
             
         return StandardConfigurer<IEncryptor>.GetConfigurerFrom(configurer);
     }
-        
+    
     /// <inheritdoc cref="EnableCustomEncryption" />
     public static StandardConfigurer<IAsyncEncryptor> EnableCustomAsyncEncryption(this OptionsConfigurer configurer)
     {

--- a/Rebus/Encryption/EncryptionKey.cs
+++ b/Rebus/Encryption/EncryptionKey.cs
@@ -1,0 +1,32 @@
+namespace Rebus.Encryption;
+
+/// <summary>
+/// Container of an encryptionkey and its identifier.
+/// </summary>
+public class EncryptionKey
+{
+    private readonly byte[] _key;
+    private readonly string _identifier;
+
+    /// <summary>
+    /// A new encryptionkey with key content and identifier.
+    /// </summary>
+    /// <param name="key">Encryptionkey as byte array.</param>
+    /// <param name="identifier">Identifier for provided key.</param>
+    public EncryptionKey(byte[] key, string identifier)
+    {
+        _key = key;
+        _identifier = identifier;
+    }
+
+    /// <summary>
+    /// Key as byte array
+    /// </summary>
+    public byte[] Key => _key;
+
+    /// <summary>
+    /// Identifier for this key.
+    /// Typically used for describing which key that was used for encrypting, and must be used for decrypting.
+    /// </summary>
+    public string Identifier => _identifier;
+}

--- a/Rebus/Encryption/IEncryptionKeyProvider.cs
+++ b/Rebus/Encryption/IEncryptionKeyProvider.cs
@@ -1,0 +1,24 @@
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Rebus.Encryption;
+
+
+/// <summary>
+/// Describes a provider capable of returning keys used for encrypting and decrypting messages 
+/// </summary>
+public interface IEncryptionKeyProvider
+{
+    /// <summary>
+    /// Returns the default key that should be used for encryption 
+    /// </summary>
+    /// <returns>An<see cref="EncryptionKey"/> containing the key and its identifier</returns>
+    public Task<EncryptionKey> GetCurrentKey();
+    
+    /// <summary>
+    /// Returns an <see cref="EncryptionKey"/> if the provider is capable finding one matching the <see cref="identifier"/>. 
+    /// </summary>
+    /// <param name="identifier">The identifier unique for this key</param>
+    /// <returns>An<see cref="EncryptionKey"/> containing the key and its identifier</returns>
+    public Task<EncryptionKey> GetSpecificKey(string identifier);
+}


### PR DESCRIPTION
- Made RijndaelEncryptor async (sync IEncryptors should still work as before)
- Added extension point for fetching encryption keys

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
