### PR TITLE
Introduces an IExceptionInfoFactory to customize the ExceptionInfo class [Refs #1122]

### DIFF
--- a/Rebus.Tests.Contracts/Errors/ExceptionInfoTests.cs
+++ b/Rebus.Tests.Contracts/Errors/ExceptionInfoTests.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Rebus.Retry;
+
+namespace Rebus.Tests.Contracts.Errors;
+
+public class ExceptionInfoTests<TExceptionInfoFactory> : FixtureBase where TExceptionInfoFactory : IExceptionInfoFactory, new()
+{
+    protected TExceptionInfoFactory _factory;
+
+    protected override void SetUp()
+    {
+        base.SetUp();
+        
+        _factory = new TExceptionInfoFactory();
+    }
+
+    [Test]
+    public async Task ThrowsOnNullException()
+    {
+        Assert.That(() => _factory.CreateInfo(null), Throws.TypeOf<ArgumentNullException>());
+    }
+
+    [Test]
+    public async Task TypeEqualsQualifiedExceptionType()
+    {
+        var info = _factory.CreateInfo(new Exception("a"));
+        Assert.That(info.Type, Is.EqualTo("System.Exception, mscorlib"));
+    }
+
+    [Test]
+    public async Task MessageIncludesExceptionMessage()
+    {
+        var info = _factory.CreateInfo(new Exception("a"));
+        Assert.That(info.Message, Contains.Substring("a"));
+    }
+
+    [Test]
+    public async Task DetailsIsNotEmpty()
+    {
+        var info = _factory.CreateInfo(new Exception("a"));
+        Assert.That(info.Details, Is.Not.Empty);
+    }
+
+    [Test]
+    public async Task TimeIsRoughlyNow()
+    {
+        var info = _factory.CreateInfo(new Exception("a"));
+        Assert.That(info.Time, Is.EqualTo(DateTimeOffset.Now).Within(TimeSpan.FromSeconds(1)));
+    }
+
+    [Test]
+    public async Task GetFullErrorDescriptionIsNotEmpty()
+    {
+        var info = _factory.CreateInfo(new Exception("a"));
+        Assert.That(info.GetFullErrorDescription(), Is.Not.Empty);
+    }
+
+    [Test]
+    public async Task ConvertToThrowsOnUnexpectedInfoType()
+    {
+        var info = _factory.CreateInfo(new Exception("a"));
+        Assert.That(() => info.ConvertTo<UnexpectedExceptionInfo>(), Throws.TypeOf<ArgumentException>());
+    }
+
+    record UnexpectedExceptionInfo : ExceptionInfo
+    {
+        public UnexpectedExceptionInfo(string Type, string Message, string Details, DateTimeOffset Time) : base(Type, Message, Details, Time) { }
+    }
+}

--- a/Rebus.Tests.Contracts/Rebus.Tests.Contracts.csproj
+++ b/Rebus.Tests.Contracts/Rebus.Tests.Contracts.csproj
@@ -28,7 +28,4 @@
 		<PackageReference Include="Newtonsoft.Json" Version="[13.0.1,14)" />
 		<PackageReference Include="NUnit" Version="3.14.0" />
 	</ItemGroup>
-	<ItemGroup>
-	  <Folder Include="Errors\" />
-	</ItemGroup>
 </Project>

--- a/Rebus.Tests/AutoMoqAttribute.cs
+++ b/Rebus.Tests/AutoMoqAttribute.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using AutoFixture.AutoMoq;
+using AutoFixture.NUnit3;
+using AutoFixture;
+
+namespace Rebus.Tests;
+
+[AttributeUsage(AttributeTargets.Method)]
+public class AutoMoqAttribute : AutoDataAttribute
+{
+    public AutoMoqAttribute() : base(CreateFixture) { }
+
+    private static IFixture CreateFixture()
+    {
+        var fixture = new Fixture();
+        fixture.Customize(new AutoMoqCustomization { ConfigureMembers = true, GenerateDelegates = true });
+        return fixture;
+    }
+}

--- a/Rebus.Tests/Rebus.Tests.csproj
+++ b/Rebus.Tests/Rebus.Tests.csproj
@@ -9,6 +9,8 @@
 		<ProjectReference Include="..\Rebus.Tests.Contracts\Rebus.Tests.Contracts.csproj" />
 	</ItemGroup>
 	<ItemGroup>
+		<PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1" />
+		<PackageReference Include="AutoFixture.NUnit3" Version="4.18.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="NUnit" Version="3.14.0" />

--- a/Rebus.Tests/Retry/ErrorTracking/InMemErrorTrackerFactory.cs
+++ b/Rebus.Tests/Retry/ErrorTracking/InMemErrorTrackerFactory.cs
@@ -1,6 +1,7 @@
 ﻿using Rebus.Logging;
 using Rebus.Retry;
 using Rebus.Retry.ErrorTracking;
+using Rebus.Retry.Info;
 using Rebus.Retry.Simple;
 using Rebus.Tests.Contracts.Errors;
 using Rebus.Tests.Time;
@@ -12,7 +13,7 @@ public class InMemErrorTrackerFactory : IErrorTrackerFactory
 {
     public IErrorTracker Create(RetryStrategySettings settings, IExceptionLogger exceptionLogger)
     {
-        return new InMemErrorTracker(settings, new TplAsyncTaskFactory(new ConsoleLoggerFactory(colored: false)), new FakeRebusTime(), exceptionLogger);
+        return new InMemErrorTracker(settings, new TplAsyncTaskFactory(new ConsoleLoggerFactory(colored: false)), new FakeRebusTime(), exceptionLogger, new ToStringExceptionInfoFactory());
     }
 
     public void Dispose()

--- a/Rebus.Tests/Retry/Info/TestInMemExceptionInfo.cs
+++ b/Rebus.Tests/Retry/Info/TestInMemExceptionInfo.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using NUnit.Framework;
+using Rebus.Retry.Info;
+using Rebus.Tests.Contracts.Errors;
+
+namespace Rebus.Tests.Retry.Info;
+
+[TestFixture]
+public class TestInMemExceptionInfo : ExceptionInfoTests<InMemExceptionInfoFactory>
+{
+    [Test]
+    public void CreatesInMemExceptionInfo()
+    {
+        var info = _factory.CreateInfo(new Exception("a"));
+        Assert.That(() => info.ConvertTo<InMemExceptionInfo>(), Throws.Nothing);
+    }
+
+    [Test]
+    public void ExceptionEqualsOriginalException()
+    {
+        var originalException = new Exception("a");
+        var info = _factory.CreateInfo(originalException).ConvertTo<InMemExceptionInfo>();
+        Assert.That(info.Exception, Is.SameAs(originalException));
+    }
+}

--- a/Rebus.Tests/Retry/Info/TestToStringExceptionInfo.cs
+++ b/Rebus.Tests/Retry/Info/TestToStringExceptionInfo.cs
@@ -1,0 +1,10 @@
+﻿using NUnit.Framework;
+using Rebus.Retry.Info;
+using Rebus.Tests.Contracts.Errors;
+
+namespace Rebus.Tests.Retry.Info;
+
+[TestFixture]
+public class TestToStringExceptionInfo : ExceptionInfoTests<ToStringExceptionInfoFactory>
+{
+}

--- a/Rebus.Tests/Retry/Simple/TestDefaultRetryStep.cs
+++ b/Rebus.Tests/Retry/Simple/TestDefaultRetryStep.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoFixture.NUnit3;
+using Moq;
+using NUnit.Framework;
+using Rebus.Exceptions;
+using Rebus.Logging;
+using Rebus.Messages;
+using Rebus.Pipeline;
+using Rebus.Retry;
+using Rebus.Retry.FailFast;
+using Rebus.Retry.Simple;
+
+namespace Rebus.Tests.Retry.Simple;
+
+[TestFixture]
+public class TestDefaultRetryStep
+{
+    [Test, AutoMoq]
+    public async Task CreatesInfoForEmptyMessageException(
+        [Frozen] Mock<IExceptionInfoFactory> exceptionInfoFactory,
+        DefaultRetryStep step, IncomingStepContext context)
+    {
+        await step.Process(context, () => Task.CompletedTask);
+        
+        exceptionInfoFactory.Verify(eif => eif.CreateInfo(It.Is<RebusApplicationException>(e => e.Message.Contains("empty"))));
+    }
+
+    [Test, AutoMoq]
+    public async Task CreatesInfoForDeadLetterCommandException(
+        [Frozen] Mock<IExceptionInfoFactory> exceptionInfoFactory,
+        DefaultRetryStep step, IncomingStepContext context,
+        TransportMessage message, string id, Exception deadLetterException)
+    {
+        message.Headers[Headers.MessageId] = id;
+        context.Save(message);
+        context.Save(new ManualDeadletterCommand(deadLetterException));
+
+        await step.Process(context, () => Task.CompletedTask);
+        
+        exceptionInfoFactory.Verify(eif => eif.CreateInfo(deadLetterException));
+    }
+
+    [Test, AutoMoq]
+    public async Task CreatesInfoForStepExceptionWhenShouldFailFast(
+        [Frozen] Mock<IFailFastChecker> failFastChecker,
+        [Frozen] Mock<IExceptionInfoFactory> exceptionInfoFactory,
+        DefaultRetryStep step, IncomingStepContext context,
+        TransportMessage message, string id, Exception nextException)
+    {
+        failFastChecker.Setup(ffc => ffc.ShouldFailFast(id, nextException)).Returns(true);
+        message.Headers[Headers.MessageId] = id;
+        context.Save(message);
+
+        await step.Process(context, () => throw nextException);
+
+        exceptionInfoFactory.Verify(eif => eif.CreateInfo(nextException));
+    }
+
+    [Test, AutoMoq]
+    public async Task CreatesInfoForSecondLevelRetryException(
+        Mock<IRebusLoggerFactory> rebusLoggerFactory,
+        Mock<IErrorHandler> errorHandler,
+        Mock<IErrorTracker> errorTracker,
+        Mock<IFailFastChecker> failFastChecker,
+        Mock<IExceptionInfoFactory> exceptionInfoFactory,
+        IncomingStepContext context,
+        TransportMessage message, string id,
+        Exception[] nextExceptions)
+    {
+        failFastChecker.Setup(ffc => ffc.ShouldFailFast(It.IsAny<string>(), It.IsAny<Exception>())).Returns(false);
+        errorTracker.Setup(et => et.HasFailedTooManyTimes(It.IsAny<string>())).ReturnsAsync(true);
+        var step = new DefaultRetryStep(rebusLoggerFactory.Object, errorHandler.Object, errorTracker.Object, failFastChecker.Object, exceptionInfoFactory.Object, true, CancellationToken.None);
+        message.Headers[Headers.MessageId] = id;
+        context.Save(message);
+
+        int i = 0;
+        await step.Process(context, () => throw nextExceptions[i++]);
+
+        exceptionInfoFactory.Verify(eif => eif.CreateInfo(nextExceptions[1]));
+    }
+}

--- a/Rebus/Config/RebusConfigurer.cs
+++ b/Rebus/Config/RebusConfigurer.cs
@@ -295,7 +295,8 @@ public class RebusConfigurer
             var asyncTaskFactory = c.Get<IAsyncTaskFactory>();
             var rebusTime = c.Get<IRebusTime>();
             var exceptionLogger = c.Get<IExceptionLogger>();
-            return new InMemErrorTracker(settings, asyncTaskFactory, rebusTime, exceptionLogger);
+            var exceptionInfoFactory = c.Get<IExceptionInfoFactory>();
+            return new InMemErrorTracker(settings, asyncTaskFactory, rebusTime, exceptionLogger, exceptionInfoFactory);
         });
 
         PossiblyRegisterDefault<IExceptionInfoFactory>(c => new ToStringExceptionInfoFactory());
@@ -317,8 +318,9 @@ public class RebusConfigurer
             var errorTracker = c.Get<IErrorTracker>();
             var errorHandler = c.Get<IErrorHandler>();
             var failFastChecker = c.Get<IFailFastChecker>();
+            var exceptionInfoFactory = c.Get<IExceptionInfoFactory>();
             var cancellationToken = c.Get<CancellationToken>();
-            return new DefaultRetryStrategy(simpleRetryStrategySettings, rebusLoggerFactory, errorTracker, errorHandler, failFastChecker, cancellationToken);
+            return new DefaultRetryStrategy(simpleRetryStrategySettings, rebusLoggerFactory, errorTracker, errorHandler, failFastChecker, exceptionInfoFactory, cancellationToken);
         });
 
         PossiblyRegisterDefault(_ => new RetryStrategySettings());

--- a/Rebus/Config/RebusConfigurer.cs
+++ b/Rebus/Config/RebusConfigurer.cs
@@ -35,6 +35,7 @@ using Rebus.Workers.ThreadPoolBased;
 using Rebus.Retry.FailFast;
 using Rebus.Time;
 using Rebus.Topic;
+using Rebus.Retry.Info;
 // ReSharper disable EmptyGeneralCatchClause
 // ReSharper disable ArgumentsStyleNamedExpression
 
@@ -296,6 +297,8 @@ public class RebusConfigurer
             var exceptionLogger = c.Get<IExceptionLogger>();
             return new InMemErrorTracker(settings, asyncTaskFactory, rebusTime, exceptionLogger);
         });
+
+        PossiblyRegisterDefault<IExceptionInfoFactory>(c => new ToStringExceptionInfoFactory());
 
         PossiblyRegisterDefault<IErrorHandler>(c =>
         {

--- a/Rebus/Retry/ErrorTracking/InMemErrorTrackerConfigurationExtensions.cs
+++ b/Rebus/Retry/ErrorTracking/InMemErrorTrackerConfigurationExtensions.cs
@@ -23,11 +23,13 @@ public static class InMemErrorTrackerConfigurationExtensions
             var asyncTaskFactory = c.Get<IAsyncTaskFactory>();
             var rebusTime = c.Get<IRebusTime>();
             var exceptionLogger = c.Get<IExceptionLogger>();
+            var exceptionInfoFactory = c.Get<IExceptionInfoFactory>();
             return new InMemErrorTracker(
                 retryStrategySettings,
                 asyncTaskFactory,
                 rebusTime,
-                exceptionLogger
+                exceptionLogger,
+                exceptionInfoFactory
             );
         });
     }

--- a/Rebus/Retry/ErrorTracking/InMemErrorTrackerConfigurationExtensions.cs
+++ b/Rebus/Retry/ErrorTracking/InMemErrorTrackerConfigurationExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Rebus.Config;
+using Rebus.Retry.Info;
 using Rebus.Retry.Simple;
 using Rebus.Threading;
 using Rebus.Time;
@@ -32,5 +33,14 @@ public static class InMemErrorTrackerConfigurationExtensions
                 exceptionInfoFactory
             );
         });
+    }
+
+    /// <summary>
+    /// Configures Rebus to use in-mem exception infos that provide the original exception via <see cref="ExceptionInfo.ConvertTo{TExceptionInfo}"/>
+    /// </summary>
+    public static void UseInMemExceptionInfos(this StandardConfigurer<IExceptionInfoFactory> configurer)
+    {
+        if (configurer == null) throw new ArgumentNullException(nameof(configurer));
+        configurer.Register(c => new InMemExceptionInfoFactory());
     }
 }

--- a/Rebus/Retry/ErrorTracking/InMemErrorTrackerConfigurationExtensions.cs
+++ b/Rebus/Retry/ErrorTracking/InMemErrorTrackerConfigurationExtensions.cs
@@ -38,9 +38,9 @@ public static class InMemErrorTrackerConfigurationExtensions
     /// <summary>
     /// Configures Rebus to use in-mem exception infos that provide the original exception via <see cref="ExceptionInfo.ConvertTo{TExceptionInfo}"/>
     /// </summary>
-    public static void UseInMemExceptionInfos(this StandardConfigurer<IExceptionInfoFactory> configurer)
+    public static void UseInMemExceptionInfos(this StandardConfigurer<IErrorTracker> configurer)
     {
         if (configurer == null) throw new ArgumentNullException(nameof(configurer));
-        configurer.Register(c => new InMemExceptionInfoFactory());
+        configurer.OtherService<IExceptionInfoFactory>().Register(c => new InMemExceptionInfoFactory());
     }
 }

--- a/Rebus/Retry/ExceptionInfo.cs
+++ b/Rebus/Retry/ExceptionInfo.cs
@@ -27,4 +27,14 @@ public record ExceptionInfo(string Type, string Message, string Details, DateTim
     /// Gets the full details of this exception info
     /// </summary>
     public string GetFullErrorDescription() => $"{Time}: {Details}";
+
+    /// <summary>
+    /// Treats the current exception info as an info of type <typeparamref name="TExceptionInfo"/>.
+    /// </summary>
+    /// <typeparam name="TExceptionInfo">Exception info subtype to convert to.</typeparam>
+    /// <returns>This exception info cast to <typeparamref name="TExceptionInfo"/>.</returns>
+    public TExceptionInfo ConvertTo<TExceptionInfo>() where TExceptionInfo : ExceptionInfo
+    {
+        return this as TExceptionInfo ?? throw new ArgumentException($"Exception info type '{GetType().Name}' cannot be cast to '{typeof(TExceptionInfo).Name}'");
+    }
 }

--- a/Rebus/Retry/IExceptionInfoFactory.cs
+++ b/Rebus/Retry/IExceptionInfoFactory.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Rebus.Retry;
+
+/// <summary>
+/// An interface to handle the creation of portable, serializable, trackable <see cref="ExceptionInfo"/>s.
+/// </summary>
+public interface IExceptionInfoFactory
+{
+    /// <summary>
+    /// Create an <see cref="ExceptionInfo"/> from an <see cref="Exception"/>.
+    /// </summary>
+    /// <param name="exception">Source exception.</param>
+    /// <returns>An <see cref="ExceptionInfo"/> containing information from the supplied exception.</returns>
+    ExceptionInfo CreateInfo(Exception exception);
+}

--- a/Rebus/Retry/Info/InMemExceptionInfo.cs
+++ b/Rebus/Retry/Info/InMemExceptionInfo.cs
@@ -1,0 +1,28 @@
+﻿using Rebus.Extensions;
+using System;
+
+namespace Rebus.Retry.Info;
+
+/// <summary>
+/// An in-memory exception info for in-memory error tracking.
+/// </summary>
+public record InMemExceptionInfo : ExceptionInfo
+{
+    /// <summary>
+    /// Constructs a new in-memory exception info from a source exception.
+    /// </summary>
+    /// <param name="exception">Source exception.</param>
+    public InMemExceptionInfo(Exception exception) : base(
+        exception?.GetType().GetSimpleAssemblyQualifiedName(),
+        exception?.Message,
+        exception?.ToString(),
+        DateTimeOffset.Now)
+    {
+        Exception = exception ?? throw new ArgumentNullException(nameof(exception));
+    }
+
+    /// <summary>
+    /// Gets or sets the original exception.
+    /// </summary>
+    public Exception Exception { get; set; }
+}

--- a/Rebus/Retry/Info/InMemExceptionInfoFactory.cs
+++ b/Rebus/Retry/Info/InMemExceptionInfoFactory.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace Rebus.Retry.Info;
+
+/// <summary>
+/// Creates <see cref="ExceptionInfo"/>s by storing the original exception.
+/// </summary>
+public class InMemExceptionInfoFactory : IExceptionInfoFactory
+{
+    /// <summary>
+    /// Create an <see cref="ExceptionInfo"/> and store the original exception.
+    /// </summary>
+    /// <remarks>
+    /// This factory only works/makes sense using an in-memory error tracker
+    /// such as <see cref="ErrorTracking.InMemErrorTracker"/>.
+    /// </remarks>
+    /// <param name="exception">Source exception.</param>
+    /// <returns>An <see cref="ExceptionInfo"/> containing information from the supplied exception.</returns>
+    public ExceptionInfo CreateInfo(Exception exception) => new InMemExceptionInfo(exception);
+}

--- a/Rebus/Retry/Info/ToStringExceptionInfoFactory.cs
+++ b/Rebus/Retry/Info/ToStringExceptionInfoFactory.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Rebus.Retry.Info;
+
+/// <summary>
+/// Creates <see cref="ExceptionInfo"/>s using a simple ToString() method.
+/// </summary>
+public class ToStringExceptionInfoFactory : IExceptionInfoFactory
+{
+    /// <summary>
+    /// Create an <see cref="ExceptionInfo"/> from <see cref="Exception.ToString()"/>.
+    /// </summary>
+    /// <param name="exception">Source exception.</param>
+    /// <returns>An <see cref="ExceptionInfo"/> containing information from the supplied exception.</returns>
+    public ExceptionInfo CreateInfo(Exception exception) => ExceptionInfo.FromException(exception);
+}

--- a/Rebus/Retry/Simple/DefaultRetryStep.cs
+++ b/Rebus/Retry/Simple/DefaultRetryStep.cs
@@ -34,18 +34,20 @@ public class DefaultRetryStep : IRetryStep
     readonly IErrorHandler _errorHandler;
     readonly IErrorTracker _errorTracker;
     readonly IFailFastChecker _failFastChecker;
+    readonly IExceptionInfoFactory _exceptionInfoFactory;
     readonly bool _secondLevelRetriesEnabled;
     readonly ILog _log;
 
     /// <summary>
     /// Creates the step
     /// </summary>
-    public DefaultRetryStep(IRebusLoggerFactory rebusLoggerFactory, IErrorHandler errorHandler, IErrorTracker errorTracker, IFailFastChecker failFastChecker, bool secondLevelRetriesEnabled, CancellationToken cancellationToken)
+    public DefaultRetryStep(IRebusLoggerFactory rebusLoggerFactory, IErrorHandler errorHandler, IErrorTracker errorTracker, IFailFastChecker failFastChecker, IExceptionInfoFactory exceptionInfoFactory, bool secondLevelRetriesEnabled, CancellationToken cancellationToken)
     {
         _log = rebusLoggerFactory?.GetLogger<DefaultRetryStep>() ?? throw new ArgumentNullException(nameof(rebusLoggerFactory));
         _errorHandler = errorHandler ?? throw new ArgumentNullException(nameof(errorHandler));
         _errorTracker = errorTracker ?? throw new ArgumentNullException(nameof(errorTracker));
         _failFastChecker = failFastChecker ?? throw new ArgumentNullException(nameof(failFastChecker));
+        _exceptionInfoFactory = exceptionInfoFactory ?? throw new ArgumentNullException(nameof(exceptionInfoFactory));
         _secondLevelRetriesEnabled = secondLevelRetriesEnabled;
         _cancellationToken = cancellationToken;
     }
@@ -64,7 +66,7 @@ public class DefaultRetryStep : IRetryStep
         {
             transactionContext.SetResult(commit: false, ack: true);
 
-            await PassToErrorHandler(context, ExceptionInfo.FromException(new RebusApplicationException(
+            await PassToErrorHandler(context, _exceptionInfoFactory.CreateInfo(new RebusApplicationException(
                 $"Received message with empty or absent '{Headers.MessageId}' header! All messages must carry" +
                 " an ID. If no ID is present, the message cannot be tracked" +
                 " between delivery attempts, and other stuff would also be much harder to" +
@@ -81,7 +83,7 @@ public class DefaultRetryStep : IRetryStep
 
             if (manualDeadletterCommand != null)
             {
-                await PassToErrorHandler(context, ExceptionInfo.FromException(manualDeadletterCommand.Exception));
+                await PassToErrorHandler(context, _exceptionInfoFactory.CreateInfo(manualDeadletterCommand.Exception));
             }
 
             transactionContext.SetResult(commit: true, ack: true);
@@ -108,7 +110,7 @@ public class DefaultRetryStep : IRetryStep
         {
             await _errorTracker.MarkAsFinal(messageId);
             await _errorTracker.RegisterError(messageId, exception);
-            await PassToErrorHandler(context, GetAggregateException(new[] { ExceptionInfo.FromException(exception) }));
+            await PassToErrorHandler(context, GetAggregateException(new[] { _exceptionInfoFactory.CreateInfo(exception) }));
             await _errorTracker.CleanUp(messageId);
             transactionContext.SetResult(commit: false, ack: true);
             return;
@@ -138,7 +140,7 @@ public class DefaultRetryStep : IRetryStep
             catch (Exception secondLevelException)
             {
                 var exceptions = await _errorTracker.GetExceptions(messageId);
-                await PassToErrorHandler(context, GetAggregateException(exceptions.Concat(new[] { ExceptionInfo.FromException(secondLevelException), })));
+                await PassToErrorHandler(context, GetAggregateException(exceptions.Concat(new[] { _exceptionInfoFactory.CreateInfo(secondLevelException), })));
                 await _errorTracker.CleanUp(messageId);
                 transactionContext.SetResult(commit: false, ack: true);
                 return;

--- a/Rebus/Retry/Simple/DefaultRetryStrategy.cs
+++ b/Rebus/Retry/Simple/DefaultRetryStrategy.cs
@@ -15,18 +15,20 @@ public class DefaultRetryStrategy : IRetryStrategy
     readonly IErrorTracker _errorTracker;
     readonly IErrorHandler _errorHandler;
     readonly IFailFastChecker _failFastChecker;
+    readonly IExceptionInfoFactory _exceptionInfoFactory;
     readonly CancellationToken _cancellationToken;
 
     /// <summary>
     /// Constructs the retry strategy with the given settings, creating an error queue with the configured name if necessary
     /// </summary>
-    public DefaultRetryStrategy(RetryStrategySettings retryStrategySettings, IRebusLoggerFactory rebusLoggerFactory, IErrorTracker errorTracker, IErrorHandler errorHandler, IFailFastChecker failFastChecker, CancellationToken cancellationToken)
+    public DefaultRetryStrategy(RetryStrategySettings retryStrategySettings, IRebusLoggerFactory rebusLoggerFactory, IErrorTracker errorTracker, IErrorHandler errorHandler, IFailFastChecker failFastChecker, IExceptionInfoFactory exceptionInfoFactory, CancellationToken cancellationToken)
     {
         _retryStrategySettings = retryStrategySettings ?? throw new ArgumentNullException(nameof(retryStrategySettings));
         _rebusLoggerFactory = rebusLoggerFactory ?? throw new ArgumentNullException(nameof(rebusLoggerFactory));
         _errorTracker = errorTracker ?? throw new ArgumentNullException(nameof(errorTracker));
         _errorHandler = errorHandler ?? throw new ArgumentNullException(nameof(errorHandler));
         _failFastChecker = failFastChecker ?? throw new ArgumentNullException(nameof(failFastChecker));
+        _exceptionInfoFactory = exceptionInfoFactory ?? throw new ArgumentNullException(nameof(exceptionInfoFactory));
         _cancellationToken = cancellationToken;
     }
 
@@ -38,6 +40,7 @@ public class DefaultRetryStrategy : IRetryStrategy
         _errorHandler,
         _errorTracker,
         _failFastChecker,
+        _exceptionInfoFactory,
         _retryStrategySettings.SecondLevelRetriesEnabled,
         _cancellationToken
     );

--- a/Rebus/Routing/TransportMessages/TransportMessageRoutingConfigurationExtensions.cs
+++ b/Rebus/Routing/TransportMessages/TransportMessageRoutingConfigurationExtensions.cs
@@ -44,8 +44,9 @@ public static class TransportMessageRoutingConfigurationExtensions
                 var transport = c.Get<ITransport>();
                 var rebusLoggerFactory = c.Get<IRebusLoggerFactory>();
                 var errorHandler = c.Get<IErrorHandler>();
+                var exceptionInfoFactory = c.Get<IExceptionInfoFactory>();
 
-                var stepToAdd = new ForwardTransportMessageStep(routingFunction, transport, rebusLoggerFactory, errorBehavior, errorHandler);
+                var stepToAdd = new ForwardTransportMessageStep(routingFunction, transport, rebusLoggerFactory, errorBehavior, errorHandler, exceptionInfoFactory);
 
                 return new PipelineStepConcatenator(pipeline)
                     .OnReceive(stepToAdd, PipelineAbsolutePosition.Front);


### PR DESCRIPTION
This PR introduces `IExceptionInfoFactory` to customize how `ExceptionInfo` classes are created from exceptions.  The main points are:

1. Classes converting exceptions into `ExceptionInfo`s now have a dependency on `IExceptionInfoFactory`.
2. The default exception info factory is just `ExceptionInfo.FromException()`, so out-of-the-box behavior should not change.
3. We also provide an `InMemExceptionInfo` (and corresponding factory) such that interested users can revert to an `ExceptionInfo` that contains the raw exception.  The new factory would have to be registered at bus configuration time to override the default.
4. Custom info users may then make use of `ExceptionInfo.ConvertTo<TInfo>()` to get their custom info.  (This is probably the kludgiest part of this approach. ☹️)

For the moment, this is just an idea to review.  If you like it, I will of course add full unit test coverage, and perhaps some configuration helpers.  If you don't like the idea, either whole or in part, please let me know how things (even tiny things) might be changed for the better.  I'll keep an eye on #1122 for discussion.

Thanks for your time!

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
