### PR TITLE
fix(Retry): do not create nested scope for ErrorHandler in DefaultRetryStep

### DIFF
--- a/Rebus/Retry/PoisonQueues/DeadletterQueueErrorHandler.cs
+++ b/Rebus/Retry/PoisonQueues/DeadletterQueueErrorHandler.cs
@@ -43,6 +43,14 @@ public class DeadletterQueueErrorHandler : IErrorHandler, IInitializable
     /// </summary>
     public async Task HandlePoisonMessage(TransportMessage transportMessage, ITransactionContext transactionContext, ExceptionInfo exception)
     {
+        // creating a separate Transaction to not enlish the Send to ErrorQueue in the original transaction that is NOT going to be commited
+        // note: there is the window where the message is sent to DeadLetter but then not ACKed due to transient network 
+        //       which lead to the original message to be handled again even if already DeadLettered.
+        using var scope = new RebusTransactionScope();
+
+        transportMessage = transportMessage.Clone();
+        transactionContext = scope.TransactionContext;
+
         var headers = transportMessage.Headers;
 
         if (!headers.TryGetValue(Headers.MessageId, out var messageId))
@@ -63,6 +71,7 @@ public class DeadletterQueueErrorHandler : IErrorHandler, IInitializable
                 messageId, errorQueueAddress, errorDetails);
 
             await _transport.Send(errorQueueAddress, transportMessage, transactionContext);
+            await scope.CompleteAsync();
         }
         catch (Exception forwardException)
         {

--- a/Rebus/Routing/TransportMessages/ForwardTransportMessageStep.cs
+++ b/Rebus/Routing/TransportMessages/ForwardTransportMessageStep.cs
@@ -95,11 +95,9 @@ public class ForwardTransportMessageStep : IIncomingStep
                 transportMessage.Headers[Headers.ErrorDetails] = exception.ToString();
 
                 try
-                {
+                {                    
+                    await _errorHandler.HandlePoisonMessage(transportMessage, transactionContext, _exceptionInfoFactory.CreateInfo(exception));
                     transactionContext.SetResult(commit: false, ack: true);
-                    using var scope = new RebusTransactionScope();
-                    await _errorHandler.HandlePoisonMessage(transportMessage, scope.TransactionContext, _exceptionInfoFactory.CreateInfo(exception));
-                    await scope.CompleteAsync();
                     return;
                 }
                 catch (Exception exception2)


### PR DESCRIPTION
ErrorHandler impl should create their own nested scope when needed.

Update the DeadletterQueueErrorHandler accordling.

fix: #1127 

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
