### PR TITLE
Add FlattenHierarchy binding flag in ActivateHandlersStep::GetDispatchMethod

### DIFF
--- a/Rebus/Pipeline/Receive/ActivateHandlersStep.cs
+++ b/Rebus/Pipeline/Receive/ActivateHandlersStep.cs
@@ -70,7 +70,7 @@ public class ActivateHandlersStep : IIncomingStep
     {
         const string methodName = nameof(GetHandlerInvokers);
 
-        var genericDispatchMethod = GetType().GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Instance)
+        var genericDispatchMethod = GetType().GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.FlattenHierarchy)
                                     ?? throw new ArgumentException($"Could not find the {methodName} method?!");
 
         return genericDispatchMethod.MakeGenericMethod(messageType);


### PR DESCRIPTION
Hi!

The class **ActivateHandlersStep** has the method CreateHandlerInvoker marked as virtual (useful++).

Trying to **override** it, I noticed in runtime that the method to make _GetHandlerInvokers_ as generic method was failing because wasn't found.

![image](https://github.com/user-attachments/assets/6dbb4c99-ccaa-4c57-803b-ae0e35b8c02c)

It could be great if it includes the binding flag flatten hierarchy so that when we extend this class we don't have to copy this method again (being able to use the original one).

Regards

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
