### PR TITLE
Performance tweaks

### DIFF
--- a/Rebus/Activation/BuiltinHandlerActivator.cs
+++ b/Rebus/Activation/BuiltinHandlerActivator.cs
@@ -139,7 +139,7 @@ public class BuiltinHandlerActivator : IContainerAdapter, IDisposable
         return this;
     }
 
-    class Handler<TMessage> : IHandleMessages<TMessage>
+    sealed class Handler<TMessage> : IHandleMessages<TMessage>
     {
         readonly Func<IBus, TMessage, Task> _handlerFunction;
         readonly Func<IBus> _getBus;

--- a/Rebus/Activation/EmptyActivator.cs
+++ b/Rebus/Activation/EmptyActivator.cs
@@ -6,7 +6,7 @@ using Rebus.Transport;
 
 namespace Rebus.Activation;
 
-class EmptyActivator : IHandlerActivator
+sealed class EmptyActivator : IHandlerActivator
 {
     public Task<IEnumerable<IHandleMessages<TMessage>>> GetHandlers<TMessage>(TMessage message, ITransactionContext transactionContext) =>
         Task.FromResult(Enumerable.Empty<IHandleMessages<TMessage>>());

--- a/Rebus/Auditing/Messages/AuditingHelper.cs
+++ b/Rebus/Auditing/Messages/AuditingHelper.cs
@@ -5,7 +5,7 @@ using Rebus.Transport;
 
 namespace Rebus.Auditing.Messages;
 
-class AuditingHelper
+sealed class AuditingHelper
 {
     readonly ITransport _transport;
     readonly IRebusTime _rebusTime;

--- a/Rebus/Auditing/Messages/IncomingAuditingStep.cs
+++ b/Rebus/Auditing/Messages/IncomingAuditingStep.cs
@@ -12,7 +12,7 @@ namespace Rebus.Auditing.Messages;
 /// Implementation of <see cref="IIncomingStep"/> and <see cref="IOutgoingStep"/> that handles message auditing
 /// </summary>
 [StepDocumentation("Wraps the execution of the entire receive pipeline and forwards a copy of the current transport message to the configured audit queue if processing was successful, including some useful headers.")]
-class IncomingAuditingStep : IIncomingStep, IInitializable
+sealed class IncomingAuditingStep : IIncomingStep, IInitializable
 {
     readonly AuditingHelper _auditingHelper;
     readonly ITransport _transport;

--- a/Rebus/Auditing/Messages/OutgoingAuditingStep.cs
+++ b/Rebus/Auditing/Messages/OutgoingAuditingStep.cs
@@ -11,7 +11,7 @@ namespace Rebus.Auditing.Messages;
 /// Implementation of <see cref="IIncomingStep"/> and <see cref="IOutgoingStep"/> that handles message auditing
 /// </summary>
 [StepDocumentation("Forwards a copy of published messages to the configured audit queue, including some useful headers.")]
-class OutgoingAuditingStep : IOutgoingStep, IInitializable
+sealed class OutgoingAuditingStep : IOutgoingStep, IInitializable
 {
     readonly AuditingHelper _auditingHelper;
     readonly ITransport _transport;

--- a/Rebus/Auditing/Sagas/LoggerSagaSnapperShotter.cs
+++ b/Rebus/Auditing/Sagas/LoggerSagaSnapperShotter.cs
@@ -8,7 +8,7 @@ using Rebus.Sagas;
 
 namespace Rebus.Auditing.Sagas;
 
-class LoggerSagaSnapperShotter : ISagaSnapshotStorage
+sealed class LoggerSagaSnapperShotter : ISagaSnapshotStorage
 {
     readonly ILog _log;
 

--- a/Rebus/Auditing/Sagas/SaveSagaDataSnapshotStep.cs
+++ b/Rebus/Auditing/Sagas/SaveSagaDataSnapshotStep.cs
@@ -13,7 +13,7 @@ using Rebus.Transport;
 namespace Rebus.Auditing.Sagas;
 
 [StepDocumentation("Saves a snapshot of each piece of saga data to the selected snapshot storage.")]
-class SaveSagaDataSnapshotStep : IIncomingStep
+sealed class SaveSagaDataSnapshotStep : IIncomingStep
 {
     readonly ISagaSnapshotStorage _sagaSnapshotStorage;
     readonly ITransport _transport;

--- a/Rebus/Bus/Advanced/AsyncHelpers.cs
+++ b/Rebus/Bus/Advanced/AsyncHelpers.cs
@@ -34,7 +34,7 @@ static class AsyncHelpers
     /// <summary>
     /// Synchronization context that can be "pumped" in order to have it execute continuations posted back to it
     /// </summary>
-    class CustomSynchronizationContext : SynchronizationContext
+    sealed class CustomSynchronizationContext : SynchronizationContext
     {
         readonly ConcurrentQueue<Tuple<SendOrPostCallback, object>> _items = new();
         readonly AutoResetEvent _workItemsWaiting = new(initialState: false);

--- a/Rebus/Bus/AdvancedRebusBus.cs
+++ b/Rebus/Bus/AdvancedRebusBus.cs
@@ -19,7 +19,7 @@ namespace Rebus.Bus;
 /// </summary>
 public partial class RebusBus
 {
-    class AdvancedApi : IAdvancedApi
+    sealed class AdvancedApi : IAdvancedApi
     {
         readonly RebusBus _rebusBus;
         readonly IRebusTime _rebusTime;
@@ -43,7 +43,7 @@ public partial class RebusBus
         public ISyncBus SyncBus => new SyncApi(_rebusBus);
     }
 
-    class TransportMessageApi : ITransportMessageApi
+    sealed class TransportMessageApi : ITransportMessageApi
     {
         readonly RebusBus _rebusBus;
         readonly IRebusTime _rebusTime;
@@ -104,7 +104,7 @@ public partial class RebusBus
         }
     }
 
-    class SyncApi : ISyncBus
+    sealed class SyncApi : ISyncBus
     {
         readonly RebusBus _rebusBus;
 
@@ -164,7 +164,7 @@ public partial class RebusBus
         }
     }
 
-    class RoutingApi : IRoutingApi
+    sealed class RoutingApi : IRoutingApi
     {
         readonly RebusBus _rebusBus;
         readonly IRebusTime _rebusTime;
@@ -217,7 +217,7 @@ public partial class RebusBus
                 destinationAddresses.Add(itinerary.GetReturnAddress);
             }
 
-            var first = destinationAddresses.First();
+            var first = destinationAddresses[0];
             var rest = destinationAddresses.Skip(1);
 
             var value = string.Join(";", rest);
@@ -230,7 +230,7 @@ public partial class RebusBus
         }
     }
 
-    class WorkersApi : IWorkersApi
+    sealed class WorkersApi : IWorkersApi
     {
         readonly RebusBus _rebusBus;
 
@@ -247,7 +247,7 @@ public partial class RebusBus
         }
     }
 
-    class TopicsApi : ITopicsApi
+    sealed class TopicsApi : ITopicsApi
     {
         readonly RebusBus _rebusBus;
 

--- a/Rebus/Compression/UnzippingSerializerDecorator.cs
+++ b/Rebus/Compression/UnzippingSerializerDecorator.cs
@@ -7,7 +7,7 @@ using Rebus.Serialization;
 
 namespace Rebus.Compression;
 
-class UnzippingSerializerDecorator : ZipDecoratorBase, ISerializer
+sealed class UnzippingSerializerDecorator : ZipDecoratorBase, ISerializer
 {
     readonly ISerializer _serializer;
     readonly Zipper _zipper;

--- a/Rebus/Compression/ZippingSerializerDecorator.cs
+++ b/Rebus/Compression/ZippingSerializerDecorator.cs
@@ -6,7 +6,7 @@ using Rebus.Serialization;
 
 namespace Rebus.Compression;
 
-class ZippingSerializerDecorator : ZipDecoratorBase, ISerializer
+sealed class ZippingSerializerDecorator : ZipDecoratorBase, ISerializer
 {
     readonly ISerializer _serializer;
     readonly Zipper _zipper;

--- a/Rebus/Config/DefaultCorrelationErrorHandler.cs
+++ b/Rebus/Config/DefaultCorrelationErrorHandler.cs
@@ -8,7 +8,7 @@ using Rebus.Sagas;
 
 namespace Rebus.Config;
 
-class DefaultCorrelationErrorHandler : ICorrelationErrorHandler
+sealed class DefaultCorrelationErrorHandler : ICorrelationErrorHandler
 {
     readonly ILog _log;
 

--- a/Rebus/Config/DelayedStartupConfigurationExtensions.cs
+++ b/Rebus/Config/DelayedStartupConfigurationExtensions.cs
@@ -40,7 +40,7 @@ public static class DelayedStartupConfigurationExtensions
         return new BusStarter(bus, desiredNumberOfWorkersWhenStarted);
     }
 
-    class BusStarter : IBusStarter
+    sealed class BusStarter : IBusStarter
     {
         readonly IBus _bus;
         readonly int _desiredNumberOfWorkersWhenStarted;

--- a/Rebus/Config/OneWayClientBusDecorator.cs
+++ b/Rebus/Config/OneWayClientBusDecorator.cs
@@ -8,7 +8,7 @@ using Rebus.Logging;
 
 namespace Rebus.Config;
 
-class OneWayClientBusDecorator : IBus
+sealed class OneWayClientBusDecorator : IBus
 {
     readonly AdvancedApiDecorator _advancedApiDecorator;
     readonly IBus _innerBus;
@@ -44,7 +44,7 @@ class OneWayClientBusDecorator : IBus
 
     public void Dispose() => _innerBus.Dispose();
 
-    class AdvancedApiDecorator : IAdvancedApi
+    sealed class AdvancedApiDecorator : IAdvancedApi
     {
         readonly IAdvancedApi _innerAdvancedApi;
         readonly IRebusLoggerFactory _rebusLoggerFactory;
@@ -68,7 +68,7 @@ class OneWayClientBusDecorator : IBus
         public ISyncBus SyncBus => _innerAdvancedApi.SyncBus;
     }
 
-    class OneWayClientWorkersApi : IWorkersApi
+    sealed class OneWayClientWorkersApi : IWorkersApi
     {
         readonly ILog _log;
 

--- a/Rebus/DataBus/ClaimCheck/HydrateIncomingMessageStep.cs
+++ b/Rebus/DataBus/ClaimCheck/HydrateIncomingMessageStep.cs
@@ -32,9 +32,9 @@ public class HydrateIncomingMessageStep : IIncomingStep
 
         if (transportMessage.Headers.TryGetValue(Headers.MessagePayloadAttachmentId, out var attachmentId))
         {
-            using var destination = new MemoryStream();
             using var source = await _dataBus.OpenRead(attachmentId);
-            
+         
+            using var destination = new MemoryStream();   
             await source.CopyToAsync(destination);
 
             var body = destination.ToArray();

--- a/Rebus/DataBus/DataBusIncomingStep.cs
+++ b/Rebus/DataBus/DataBusIncomingStep.cs
@@ -4,7 +4,7 @@ using Rebus.Pipeline;
 
 namespace Rebus.DataBus;
 
-class DataBusIncomingStep : IIncomingStep
+sealed class DataBusIncomingStep : IIncomingStep
 {
     public const string DataBusStorageKey = "rebus-databus-storage";
 

--- a/Rebus/DataBus/DefaultDataBus.cs
+++ b/Rebus/DataBus/DefaultDataBus.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace Rebus.DataBus;
 
-class DefaultDataBus : IDataBus
+sealed class DefaultDataBus : IDataBus
 {
     readonly IDataBusStorage _dataBusStorage;
     readonly IDataBusStorageManagement _dataBusStorageManagement;

--- a/Rebus/DataBus/FileSystem/Retrier.cs
+++ b/Rebus/DataBus/FileSystem/Retrier.cs
@@ -4,7 +4,7 @@ using Rebus.Logging;
 
 namespace Rebus.DataBus.FileSystem;
 
-class Retrier
+sealed class Retrier
 {
     readonly ILog _log;
 

--- a/Rebus/DataBus/InMem/InMemDataBusStorage.cs
+++ b/Rebus/DataBus/InMem/InMemDataBusStorage.cs
@@ -9,7 +9,7 @@ using Rebus.Time;
 
 namespace Rebus.DataBus.InMem;
 
-class InMemDataBusStorage : IDataBusStorage, IDataBusStorageManagement
+sealed class InMemDataBusStorage : IDataBusStorage, IDataBusStorageManagement
 {
     readonly InMemDataStore _dataStore;
     readonly IRebusTime _rebusTime;

--- a/Rebus/DataBus/InMem/InMemDataStore.cs
+++ b/Rebus/DataBus/InMem/InMemDataStore.cs
@@ -101,7 +101,7 @@ public class InMemDataStore
         _data.Clear();
     }
 
-    class InMemBlob
+    sealed class InMemBlob
     {
         public InMemBlob(Dictionary<string, string> metadata, byte[] data)
         {

--- a/Rebus/Encryption/AesEncryptor.cs
+++ b/Rebus/Encryption/AesEncryptor.cs
@@ -9,7 +9,7 @@ namespace Rebus.Encryption;
 /// <summary>
 /// Helps with encrypting/decrypting byte arrays, using the <see cref="Aes"/> algorithm
 /// </summary>
-class AesEncryptor : IAsyncEncryptor
+sealed class AesEncryptor : IAsyncEncryptor
 {
     readonly IEncryptionKeyProvider _keyProvider;
 

--- a/Rebus/Encryption/DefaultAsyncEncryptor.cs
+++ b/Rebus/Encryption/DefaultAsyncEncryptor.cs
@@ -6,7 +6,7 @@ namespace Rebus.Encryption;
 /// <summary>
 /// Default implementation of <see cref="IAsyncEncryptor"/> which wraps an instance of <see cref="IEncryptor"/>.
 /// </summary>
-class DefaultAsyncEncryptor : IAsyncEncryptor
+sealed class DefaultAsyncEncryptor : IAsyncEncryptor
 {
     readonly IEncryptor _encryptor;
 

--- a/Rebus/Encryption/RijndaelEncryptor.cs
+++ b/Rebus/Encryption/RijndaelEncryptor.cs
@@ -9,7 +9,7 @@ namespace Rebus.Encryption;
 /// <summary>
 /// Helps with encrypting/decrypting byte arrays, using the <see cref="RijndaelManaged"/> algorithm (which is actually AES with 256 bits key size)
 /// </summary>
-class RijndaelEncryptor : IAsyncEncryptor
+sealed class RijndaelEncryptor : IAsyncEncryptor
 {
     readonly IEncryptionKeyProvider _keyProvider;
 

--- a/Rebus/ExclusiveLocks/ConcurrentDictionaryExclusiveAccessLock.cs
+++ b/Rebus/ExclusiveLocks/ConcurrentDictionaryExclusiveAccessLock.cs
@@ -7,7 +7,7 @@ namespace Rebus.ExclusiveLocks;
 /// <summary>
 /// ConcurrentDictionary implementation of <see cref="IExclusiveAccessLock"/>
 /// </summary>
-class ConcurrentDictionaryExclusiveAccessLock : IExclusiveAccessLock
+sealed class ConcurrentDictionaryExclusiveAccessLock : IExclusiveAccessLock
 {
     static readonly Task<bool> TrueResult = Task.FromResult(true);
     static readonly Task<bool> FalseResult = Task.FromResult(false);

--- a/Rebus/Handlers/InternalHandlersContributor.cs
+++ b/Rebus/Handlers/InternalHandlersContributor.cs
@@ -48,7 +48,7 @@ sealed class InternalHandlersContributor : IHandlerActivator
             : Enumerable.Empty<IHandleMessages<TMessage>>();
     }
 
-    class SubscribeRequestHandler : IHandleMessages<SubscribeRequest>
+    sealed class SubscribeRequestHandler : IHandleMessages<SubscribeRequest>
     {
         readonly ISubscriptionStorage _subscriptionStorage;
 
@@ -63,7 +63,7 @@ sealed class InternalHandlersContributor : IHandlerActivator
         }
     }
 
-    class UnsubscribeRequestHandler : IHandleMessages<UnsubscribeRequest>
+    sealed class UnsubscribeRequestHandler : IHandleMessages<UnsubscribeRequest>
     {
         readonly ISubscriptionStorage _subscriptionStorage;
 

--- a/Rebus/Handlers/InternalHandlersContributor.cs
+++ b/Rebus/Handlers/InternalHandlersContributor.cs
@@ -13,7 +13,7 @@ namespace Rebus.Handlers;
 /// Decoration of <see cref="IHandlerActivator"/> that adds a few special handlers when an incoming message can be recognized
 /// as a special Rebus message
 /// </summary>
-class InternalHandlersContributor : IHandlerActivator
+sealed class InternalHandlersContributor : IHandlerActivator
 {
     readonly IHandlerActivator _innerHandlerActivator;
     readonly Dictionary<Type, IHandleMessages[]> _internalHandlers;

--- a/Rebus/Injection/Injectionist.cs
+++ b/Rebus/Injection/Injectionist.cs
@@ -251,6 +251,6 @@ public class Injectionist
             }
         }
 
-        public IEnumerable TrackedInstances => _resolvedInstances.ToList();
+        public IEnumerable TrackedInstances => _resolvedInstances.ToArray();
     }
 }

--- a/Rebus/Injection/Injectionist.cs
+++ b/Rebus/Injection/Injectionist.cs
@@ -96,9 +96,7 @@ public class Injectionist
     {
         var key = typeof(TService);
 
-        if (!resolvers.ContainsKey(key)) return false;
-
-        var handler = resolvers[key];
+        if (!resolvers.TryGetValue(key, out var handler)) return false;
 
         if (handler.PrimaryResolver != null) return true;
 

--- a/Rebus/Injection/Injectionist.cs
+++ b/Rebus/Injection/Injectionist.cs
@@ -12,7 +12,7 @@ namespace Rebus.Injection;
 /// </summary>
 public class Injectionist
 {
-    class Handler
+    sealed class Handler
     {
         public Handler()
         {
@@ -145,7 +145,7 @@ public class Injectionist
         public bool IsDecorator { get; private set; }
     }
 
-    class Resolver<TService> : Resolver
+    sealed class Resolver<TService> : Resolver
     {
         readonly Func<IResolutionContext, TService> _resolver;
         readonly string _description;
@@ -173,7 +173,7 @@ public class Injectionist
         }
     }
 
-    class ResolutionContext : IResolutionContext
+    sealed class ResolutionContext : IResolutionContext
     {
         readonly Dictionary<Type, int> _decoratorDepth = new Dictionary<Type, int>();
         readonly Dictionary<Type, Handler> _resolvers;

--- a/Rebus/Logging/ConsoleLoggerFactory.cs
+++ b/Rebus/Logging/ConsoleLoggerFactory.cs
@@ -108,7 +108,7 @@ public class ConsoleLoggerFactory : AbstractRebusLoggerFactory
     /// </summary>
     protected override ILog GetLogger(Type type) => Loggers.GetOrAdd(type, _ => new ConsoleLogger(type, _colors, this, _showTimestamps));
 
-    class ConsoleLogger : ILog
+    sealed class ConsoleLogger : ILog
     {
         readonly LoggingColors _loggingColors;
         readonly ConsoleLoggerFactory _factory;

--- a/Rebus/Logging/NullLoggerFactory.cs
+++ b/Rebus/Logging/NullLoggerFactory.cs
@@ -17,7 +17,7 @@ public class NullLoggerFactory : AbstractRebusLoggerFactory
         return Logger;
     }
 
-    class NullLogger : ILog
+    sealed class NullLogger : ILog
     {
         public void Debug(string message, params object[] objs)
         {

--- a/Rebus/Logging/TraceLoggerFactory.cs
+++ b/Rebus/Logging/TraceLoggerFactory.cs
@@ -16,7 +16,7 @@ public class TraceLoggerFactory : AbstractRebusLoggerFactory
         return new TraceLogger(type, this);
     }
 
-    class TraceLogger : ILog
+    sealed class TraceLogger : ILog
     {
         readonly Type _type;
         readonly TraceLoggerFactory _loggerFactory;

--- a/Rebus/Persistence/FileSystem/FileSystemSagaSnapshotStorage.cs
+++ b/Rebus/Persistence/FileSystem/FileSystemSagaSnapshotStorage.cs
@@ -69,7 +69,7 @@ public class FileSystemSagaSnapshotStorage : ISagaSnapshotStorage, IInitializabl
         }
     }
 
-    class Snapshot
+    sealed class Snapshot
     {
         public Dictionary<string, string> Metadata { get; set; }
         public ISagaData Data { get; set; }

--- a/Rebus/Persistence/FileSystem/FilesystemExclusiveLock.cs
+++ b/Rebus/Persistence/FileSystem/FilesystemExclusiveLock.cs
@@ -5,7 +5,7 @@ using Rebus.Logging;
 
 namespace Rebus.Persistence.FileSystem;
 
-class FileSystemExclusiveLock : IDisposable
+sealed class FileSystemExclusiveLock : IDisposable
 {
     readonly FileStream _fileStream;
     bool _disposed;

--- a/Rebus/Persistence/FileSystem/FilesystemSagaIndex.cs
+++ b/Rebus/Persistence/FileSystem/FilesystemSagaIndex.cs
@@ -7,7 +7,7 @@ using Rebus.Sagas;
 
 namespace Rebus.Persistence.FileSystem;
 
-class FileSystemSagaIndex
+sealed class FileSystemSagaIndex
 {
     readonly string _basePath;
 
@@ -40,7 +40,7 @@ class FileSystemSagaIndex
         var indexItems = ReadIndexItems();
 
         var item = indexItems
-            .FirstOrDefault(i => i.SagaType == sagaDataType.FullName
+            .Find(i => i.SagaType == sagaDataType.FullName
                                  && i.PropertyName == propertyName
                                  && i.PropertyValue == propertyValue?.ToString());
 

--- a/Rebus/Persistence/FileSystem/FilesystemSagaIndex.cs
+++ b/Rebus/Persistence/FileSystem/FilesystemSagaIndex.cs
@@ -126,7 +126,7 @@ sealed class FileSystemSagaIndex
         return obj;
     }
 
-    class SagaIndexItem
+    sealed class SagaIndexItem
     {
         public string SagaType { get; set; }
         public string PropertyName { get; set; }

--- a/Rebus/Persistence/FileSystem/FilesystemTimeoutManager.cs
+++ b/Rebus/Persistence/FileSystem/FilesystemTimeoutManager.cs
@@ -89,7 +89,7 @@ public class FileSystemTimeoutManager : ITimeoutManager
         return new DueMessagesResult(items, async () => { lockItem.Dispose(); });
     }
 
-    class Timeout
+    sealed class Timeout
     {
         public Dictionary<string, string> Headers { get; set; }
         public byte[] Body { get; set; }

--- a/Rebus/Persistence/FileSystem/ReaderWriterLockSlimExtensions.cs
+++ b/Rebus/Persistence/FileSystem/ReaderWriterLockSlimExtensions.cs
@@ -15,7 +15,7 @@ static class ReaderWriterLockSlimExtensions
         return new DisposableWriteLock(readerWriterLockSlim);
     }
 
-    class DisposableReadLock : IDisposable
+    sealed class DisposableReadLock : IDisposable
     {
         readonly ReaderWriterLockSlim _readerWriterLockSlim;
 
@@ -31,7 +31,7 @@ static class ReaderWriterLockSlimExtensions
         }
     }
 
-    class DisposableWriteLock : IDisposable
+    sealed class DisposableWriteLock : IDisposable
     {
         readonly ReaderWriterLockSlim _readerWriterLockSlim;
 

--- a/Rebus/Persistence/Throwing/DisabledDataBus.cs
+++ b/Rebus/Persistence/Throwing/DisabledDataBus.cs
@@ -6,7 +6,7 @@ using Rebus.DataBus;
 
 namespace Rebus.Persistence.Throwing;
 
-class DisabledDataBus : IDataBus
+sealed class DisabledDataBus : IDataBus
 {
     public Task<DataBusAttachment> CreateAttachment(Stream source, Dictionary<string, string> optionalMetadata = null) => throw GetException();
 

--- a/Rebus/Persistence/Throwing/DisabledDataBusStorageManagement.cs
+++ b/Rebus/Persistence/Throwing/DisabledDataBusStorageManagement.cs
@@ -5,7 +5,7 @@ using Rebus.DataBus;
 
 namespace Rebus.Persistence.Throwing;
 
-class DisabledDataBusStorageManagement : IDataBusStorageManagement
+sealed class DisabledDataBusStorageManagement : IDataBusStorageManagement
 {
     public Task Delete(string id) => throw GetException();
 

--- a/Rebus/Persistence/Throwing/DisabledSagaStorage.cs
+++ b/Rebus/Persistence/Throwing/DisabledSagaStorage.cs
@@ -5,7 +5,7 @@ using Rebus.Sagas;
 
 namespace Rebus.Persistence.Throwing;
 
-class DisabledSagaStorage : ISagaStorage
+sealed class DisabledSagaStorage : ISagaStorage
 {
     public Task<ISagaData> Find(Type sagaDataType, string propertyName, object propertyValue) => throw GetException();
 

--- a/Rebus/Persistence/Throwing/DisabledSubscriptionStorage.cs
+++ b/Rebus/Persistence/Throwing/DisabledSubscriptionStorage.cs
@@ -5,7 +5,7 @@ using Rebus.Subscriptions;
 
 namespace Rebus.Persistence.Throwing;
 
-class DisabledSubscriptionStorage : ISubscriptionStorage
+sealed class DisabledSubscriptionStorage : ISubscriptionStorage
 {
     public Task<IReadOnlyList<string>> GetSubscriberAddresses(string topic) => throw GetException();
 

--- a/Rebus/Persistence/Throwing/DisabledTimeoutManager.cs
+++ b/Rebus/Persistence/Throwing/DisabledTimeoutManager.cs
@@ -5,7 +5,7 @@ using Rebus.Timeouts;
 
 namespace Rebus.Persistence.Throwing;
 
-class DisabledTimeoutManager : ITimeoutManager
+sealed class DisabledTimeoutManager : ITimeoutManager
 {
     public Task Defer(DateTimeOffset approximateDueTime, Dictionary<string, string> headers, byte[] body) => throw GetException();
 

--- a/Rebus/Pipeline/Invokers/ActionPipelineInvoker.cs
+++ b/Rebus/Pipeline/Invokers/ActionPipelineInvoker.cs
@@ -8,7 +8,7 @@ namespace Rebus.Pipeline.Invokers;
 /// <summary>
 /// Action-based pipeline invoker that recursively composes actions to invoke the pipelines
 /// </summary>
-class ActionPipelineInvoker : IPipelineInvoker
+sealed class ActionPipelineInvoker : IPipelineInvoker
 {
     static readonly Task CompletedTask = Task.FromResult(0);
 
@@ -48,7 +48,7 @@ class ActionPipelineInvoker : IPipelineInvoker
             return CompletedFunction;
         }
 
-        var head = steps.First();
+        var head = steps[0];
         var tail = steps.Skip(1).ToList();
         var invokeTail = GenerateReceiveFunction(tail);
 
@@ -69,7 +69,7 @@ class ActionPipelineInvoker : IPipelineInvoker
             return CompletedFunction;
         }
 
-        var head = steps.First();
+        var head = steps[0];
         var tail = steps.Skip(1).ToList();
         var invokeTail = GenerateSendFunction(tail);
 

--- a/Rebus/Pipeline/Invokers/ActionPipelineInvoker.cs
+++ b/Rebus/Pipeline/Invokers/ActionPipelineInvoker.cs
@@ -8,8 +8,6 @@ namespace Rebus.Pipeline.Invokers;
 /// </summary>
 sealed class ActionPipelineInvoker : IPipelineInvoker
 {
-    static readonly Task CompletedTask = Task.FromResult(0);
-
     readonly Func<IncomingStepContext, Task> _invokeReceivePipeline;
     readonly Func<OutgoingStepContext, Task> _invokeSendPipeline;
 
@@ -42,7 +40,7 @@ sealed class ActionPipelineInvoker : IPipelineInvoker
     {
         if (steps.IsEmpty)
         {
-            Task CompletedFunction(IncomingStepContext context) => CompletedTask;
+            Task CompletedFunction(IncomingStepContext context) => Task.CompletedTask;
             return CompletedFunction;
         }
 
@@ -63,7 +61,7 @@ sealed class ActionPipelineInvoker : IPipelineInvoker
     {
         if (steps.IsEmpty)
         {
-            Task CompletedFunction(OutgoingStepContext context) => CompletedTask;
+            Task CompletedFunction(OutgoingStepContext context) => Task.CompletedTask;
             return CompletedFunction;
         }
 

--- a/Rebus/Pipeline/Invokers/ActionPipelineInvoker.cs
+++ b/Rebus/Pipeline/Invokers/ActionPipelineInvoker.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace Rebus.Pipeline.Invokers;
@@ -40,16 +38,16 @@ sealed class ActionPipelineInvoker : IPipelineInvoker
         return _invokeSendPipeline(context);
     }
 
-    static Func<IncomingStepContext, Task> GenerateReceiveFunction(IReadOnlyList<IIncomingStep> steps)
+    static Func<IncomingStepContext, Task> GenerateReceiveFunction(Span<IIncomingStep> steps)
     {
-        if (!steps.Any())
+        if (steps.IsEmpty)
         {
             Task CompletedFunction(IncomingStepContext context) => CompletedTask;
             return CompletedFunction;
         }
 
         var head = steps[0];
-        var tail = steps.Skip(1).ToList();
+        var tail = steps.Slice(1);
         var invokeTail = GenerateReceiveFunction(tail);
 
         Task ReceiveFunction(IncomingStepContext context)
@@ -61,16 +59,16 @@ sealed class ActionPipelineInvoker : IPipelineInvoker
         return ReceiveFunction;
     }
 
-    static Func<OutgoingStepContext, Task> GenerateSendFunction(IReadOnlyList<IOutgoingStep> steps)
+    static Func<OutgoingStepContext, Task> GenerateSendFunction(Span<IOutgoingStep> steps)
     {
-        if (!steps.Any())
+        if (steps.IsEmpty)
         {
             Task CompletedFunction(OutgoingStepContext context) => CompletedTask;
             return CompletedFunction;
         }
 
         var head = steps[0];
-        var tail = steps.Skip(1).ToList();
+        var tail = steps.Slice(1);
         var invokeTail = GenerateSendFunction(tail);
 
         Task SendFunction(OutgoingStepContext context)

--- a/Rebus/Pipeline/Invokers/DefaultPipelineInvoker.cs
+++ b/Rebus/Pipeline/Invokers/DefaultPipelineInvoker.cs
@@ -7,7 +7,7 @@ namespace Rebus.Pipeline.Invokers;
 /// <summary>
 /// give me a pipeline and I'll invoke it
 /// </summary>
-class DefaultPipelineInvoker : IPipelineInvoker
+sealed class DefaultPipelineInvoker : IPipelineInvoker
 {
     static readonly Task<int> Noop = Task.FromResult(0);
     static readonly Func<Task> TerminationStep = () => Noop;

--- a/Rebus/Pipeline/Invokers/DefaultPipelineInvokerNew.cs
+++ b/Rebus/Pipeline/Invokers/DefaultPipelineInvokerNew.cs
@@ -6,7 +6,7 @@ namespace Rebus.Pipeline.Invokers;
 /// <summary>
 /// give me a pipeline and I'll invoke it
 /// </summary>
-class DefaultPipelineInvokerNew : IPipelineInvoker
+sealed class DefaultPipelineInvokerNew : IPipelineInvoker
 {
     static readonly Task Noop = Task.CompletedTask;
 

--- a/Rebus/Pipeline/Receive/ActivateHandlersStep.cs
+++ b/Rebus/Pipeline/Receive/ActivateHandlersStep.cs
@@ -55,8 +55,7 @@ public class ActivateHandlersStep : IIncomingStep
         var handlers = await _handlerActivator.GetHandlers(message, transactionContext);
 
         var listOfHandlerInvokers = handlers
-            .Select(handler => CreateHandlerInvoker(handler, message, transactionContext, logicalMessage))
-            .ToList();
+            .Select(handler => CreateHandlerInvoker(handler, message, transactionContext, logicalMessage));
 
         return new HandlerInvokers(logicalMessage, listOfHandlerInvokers);
     }

--- a/Rebus/Pipeline/Receive/ActivateHandlersStep.cs
+++ b/Rebus/Pipeline/Receive/ActivateHandlersStep.cs
@@ -37,7 +37,7 @@ public class ActivateHandlersStep : IIncomingStep
         var message = context.Load<Message>();
         var body = message.Body;
         var messageType = body.GetType();
-        var methodToInvoke = _dispatchMethods.GetOrAdd(messageType, _ => GetDispatchMethod(messageType));
+        var methodToInvoke = _dispatchMethods.GetOrAdd(messageType, GetDispatchMethod);
 
         var args = new[] { body, transactionContext, message };
         var handlerInvokers = await (Task<HandlerInvokers>)methodToInvoke.Invoke(this, args);

--- a/Rebus/Pipeline/Receive/HandleDeferredMessagesStep.cs
+++ b/Rebus/Pipeline/Receive/HandleDeferredMessagesStep.cs
@@ -122,7 +122,7 @@ public class HandleDeferredMessagesStep : IIncomingStep, IDisposable, IInitializ
             {
                 throw new RebusApplicationException(
                     $"Received message {headers[Headers.MessageId]} with the '{Headers.DeferredUntil}' header" +
-                    $" set to '{headers[Headers.DeferredUntil]}', but the message had no" +
+                    $" set to '{deferredUntil}', but the message had no" +
                     $" '{Headers.DeferredRecipient}' header!");
             }
 

--- a/Rebus/Pipeline/Receive/HandlerInvoker.cs
+++ b/Rebus/Pipeline/Receive/HandlerInvoker.cs
@@ -164,7 +164,7 @@ public class HandlerInvoker<TMessage> : HandlerInvoker
     const string SagaDataPropertyName = nameof(Saga<ConcreteSagaData>.Data); //< for refactoring tools to better see it
 
     // ReSharper disable once ClassNeverInstantiated.Local
-    class ConcreteSagaData : SagaData { } //< in order to be able to declare the const above
+    sealed class ConcreteSagaData : SagaData { } //< in order to be able to declare the const above
 
     /// <summary>
     /// Sets a saga instance on the handler

--- a/Rebus/Pipeline/Send/AutoHeadersOutgoingStep.cs
+++ b/Rebus/Pipeline/Send/AutoHeadersOutgoingStep.cs
@@ -31,7 +31,7 @@ public class AutoHeadersOutgoingStep : IOutgoingStep
 
         var messageType = body.GetType();
 
-        var headersToAssign = _headersToAssign.GetOrAdd(messageType, type => messageType
+        var headersToAssign = _headersToAssign.GetOrAdd(messageType, nonCapturedMessageType => nonCapturedMessageType
             .GetTypeInfo()
             .GetCustomAttributes(typeof (HeaderAttribute), true)
             .OfType<HeaderAttribute>()

--- a/Rebus/Profiling/PipelineStepProfiler.cs
+++ b/Rebus/Profiling/PipelineStepProfiler.cs
@@ -47,7 +47,7 @@ public class PipelineStepProfiler : IPipeline
     }
 
     [StepDocumentation("Collected profiler measurements and registers them with the stats collector")]
-    class RegisterCollectedProfilerStatsStep : IIncomingStep
+    sealed class RegisterCollectedProfilerStatsStep : IIncomingStep
     {
         readonly PipelineStepProfilerStats _profilerStats;
 
@@ -67,7 +67,7 @@ public class PipelineStepProfiler : IPipeline
     }
 
     [StepDocumentation("Measures time spent in the rest of the pipeline")]
-    class ProfilerStep : IIncomingStep
+    sealed class ProfilerStep : IIncomingStep
     {
         readonly IIncomingStep _nextStep;
 

--- a/Rebus/Profiling/StatsContext.cs
+++ b/Rebus/Profiling/StatsContext.cs
@@ -27,7 +27,7 @@ sealed class StatsContext
 
     internal IDisposable Measure(IIncomingStep nextStep) => new StatsContextDisposable(this, nextStep);
 
-    class StatsContextDisposable : IDisposable
+    sealed class StatsContextDisposable : IDisposable
     {
         readonly StatsContext _statsContext;
         readonly IIncomingStep _nextStep;

--- a/Rebus/Profiling/StatsContext.cs
+++ b/Rebus/Profiling/StatsContext.cs
@@ -7,7 +7,7 @@ using Rebus.Pipeline;
 
 namespace Rebus.Profiling;
 
-class StatsContext
+sealed class StatsContext
 {
     readonly ConcurrentStack<Measurement> _measurements = new ConcurrentStack<Measurement>();
 

--- a/Rebus/Reflection/Ponder.cs
+++ b/Rebus/Reflection/Ponder.cs
@@ -3,7 +3,7 @@ using System.Linq.Expressions;
 
 namespace Rebus.Reflection;
 
-class Reflect
+sealed class Reflect
 {
     public static string Path<T>(Expression<Func<T, object>> expression)
     {

--- a/Rebus/Retry/ErrorTracking/InMemErrorTracker.cs
+++ b/Rebus/Retry/ErrorTracking/InMemErrorTracker.cs
@@ -156,7 +156,7 @@ public class InMemErrorTracker : IErrorTracker, IInitializable, IDisposable
 
     void RemoveTracking(string messageId) => _trackedErrors.TryRemove(messageId, out _);
 
-    class ErrorTracking
+    sealed class ErrorTracking
     {
         readonly IRebusTime _rebusTime;
         readonly ExceptionInfo[] _caughtExceptions;

--- a/Rebus/Retry/FailFast/FailFastConfigurationExtension.cs
+++ b/Rebus/Retry/FailFast/FailFastConfigurationExtension.cs
@@ -24,7 +24,7 @@ public static class FailFastConfigurationExtension
         });
     }
 
-    class FailFastOnSpecificExceptionTypeAndPredicate<TException> : IFailFastChecker where TException : Exception
+    sealed class FailFastOnSpecificExceptionTypeAndPredicate<TException> : IFailFastChecker where TException : Exception
     {
         readonly IFailFastChecker _failFastChecker;
         readonly Func<TException, bool> _predicate;

--- a/Rebus/Retry/Simple/DefaultExceptionLogger.cs
+++ b/Rebus/Retry/Simple/DefaultExceptionLogger.cs
@@ -3,7 +3,7 @@ using Rebus.Logging;
 
 namespace Rebus.Retry.Simple;
 
-class DefaultExceptionLogger : IExceptionLogger
+sealed class DefaultExceptionLogger : IExceptionLogger
 {
     readonly ILog _log;
 

--- a/Rebus/Retry/Simple/FailedMessageWrapper.cs
+++ b/Rebus/Retry/Simple/FailedMessageWrapper.cs
@@ -7,7 +7,7 @@ namespace Rebus.Retry.Simple;
 /// <summary>
 /// Wraps a failed message that is to be retried
 /// </summary>
-class FailedMessageWrapper<TMessage> : IFailed<TMessage>
+sealed class FailedMessageWrapper<TMessage> : IFailed<TMessage>
 {
     /// <summary>
     /// Gets the message that failed

--- a/Rebus/Retry/Simple/FailedMessageWrapperStep.cs
+++ b/Rebus/Retry/Simple/FailedMessageWrapperStep.cs
@@ -17,7 +17,7 @@ namespace Rebus.Retry.Simple;
 
 This is carried out by having the retry step add the '" + DefaultRetryStep.DispatchAsFailedMessageKey + @"' key to the context,
 which is then detected by this wrapper step.")]
-class FailedMessageWrapperStep : IIncomingStep
+sealed class FailedMessageWrapperStep : IIncomingStep
 {
     readonly IErrorTracker _errorTracker;
 

--- a/Rebus/Retry/Simple/VerifyCannotSendFailedMessageWrapperStep.cs
+++ b/Rebus/Retry/Simple/VerifyCannotSendFailedMessageWrapperStep.cs
@@ -8,7 +8,7 @@ using Rebus.Pipeline;
 namespace Rebus.Retry.Simple;
 
 [StepDocumentation("When 2nd level retries are enabled, it is easy to accidentally Send/Defer the incoming IFailed<TMessage> instead of the TMessage. This step prohibits that.")]
-class VerifyCannotSendFailedMessageWrapperStep : IOutgoingStep
+sealed class VerifyCannotSendFailedMessageWrapperStep : IOutgoingStep
 {
     public async Task Process(OutgoingStepContext context, Func<Task> next)
     {

--- a/Rebus/Routing/Exceptions/AutoForwardOnExceptionConfigurationExtensions.cs
+++ b/Rebus/Routing/Exceptions/AutoForwardOnExceptionConfigurationExtensions.cs
@@ -52,7 +52,7 @@ public static class AutoForwardOnExceptionConfigurationExtensions
     }
 
     [StepDocumentation("Wraps the invocation of the rest of the pipeline in a try-catch block, immediately forwarding the message to another queue when some specific exception (or any derived exception type) is caught.")]
-    class ForwardOnExceptionsStep : IIncomingStep
+    sealed class ForwardOnExceptionsStep : IIncomingStep
     {
         readonly Type _exceptionType;
         readonly string _destinationQueue;

--- a/Rebus/Routing/TypeBased/TypeBasedRouter.cs
+++ b/Rebus/Routing/TypeBased/TypeBasedRouter.cs
@@ -184,11 +184,11 @@ public class TypeBasedRouter : IRouter
         if (messageType == null) throw new ArgumentNullException(nameof(messageType));
         if (destinationAddress == null) throw new ArgumentNullException(nameof(destinationAddress));
 
-        if (_messageTypeAddresses.ContainsKey(messageType) &&
-            _messageTypeAddresses[messageType] != destinationAddress)
+        if (_messageTypeAddresses.TryGetValue(messageType, out var messageTypeAddress) &&
+            messageTypeAddress != destinationAddress)
         {
             _log.Warn("Existing endpoint mapping {messageType} -> {queueName} changed to -> {newQueueName}",
-                messageType, _messageTypeAddresses[messageType], destinationAddress);
+                messageType, messageTypeAddress, destinationAddress);
         }
         else
         {

--- a/Rebus/Sagas/Exclusive/EnforceExclusiveSagaAccessIncomingStep.cs
+++ b/Rebus/Sagas/Exclusive/EnforceExclusiveSagaAccessIncomingStep.cs
@@ -7,7 +7,7 @@ using Rebus.Pipeline;
 namespace Rebus.Sagas.Exclusive;
 
 [StepDocumentation("Enforces exclusive access to saga data in the rest of the pipeline by acquiring locks for the relevant correlation properties.")]
-class EnforceExclusiveSagaAccessIncomingStep : EnforceExclusiveSagaAccessIncomingStepBase
+sealed class EnforceExclusiveSagaAccessIncomingStep : EnforceExclusiveSagaAccessIncomingStepBase
 {
     readonly IExclusiveAccessLock _lockHandler;
     readonly string _lockPrefix;

--- a/Rebus/Sagas/Exclusive/SemaphoreSlimExclusiveSagaAccessIncomingStep.cs
+++ b/Rebus/Sagas/Exclusive/SemaphoreSlimExclusiveSagaAccessIncomingStep.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Rebus.Sagas.Exclusive;
 
-class SemaphoreSlimExclusiveSagaAccessIncomingStep : EnforceExclusiveSagaAccessIncomingStepBase, IDisposable
+sealed class SemaphoreSlimExclusiveSagaAccessIncomingStep : EnforceExclusiveSagaAccessIncomingStepBase, IDisposable
 {
     readonly SemaphoreSlim[] _locks;
 

--- a/Rebus/Sagas/Idempotent/IdempotencyData.cs
+++ b/Rebus/Sagas/Idempotent/IdempotencyData.cs
@@ -48,7 +48,7 @@ public class IdempotencyData
     /// </summary>
     public IEnumerable<OutgoingMessage> GetOutgoingMessages(string messageId)
     {
-        var outgoingMessages = OutgoingMessages.FirstOrDefault(o => o.MessageId == messageId);
+        var outgoingMessages = OutgoingMessages.Find(o => o.MessageId == messageId);
 
         return outgoingMessages != null
             ? outgoingMessages.MessagesToSend
@@ -75,7 +75,7 @@ public class IdempotencyData
     {
         HandledMessageIds.Add(messageId);
 
-        var outgoingMessages = OutgoingMessages.FirstOrDefault(o => o.MessageId == messageId);
+        var outgoingMessages = OutgoingMessages.Find(o => o.MessageId == messageId);
 
         if (outgoingMessages != null) return outgoingMessages;
 

--- a/Rebus/Sagas/LoadSagaDataStep.cs
+++ b/Rebus/Sagas/LoadSagaDataStep.cs
@@ -238,7 +238,7 @@ public class LoadSagaDataStep : IIncomingStep
         }
     }
 
-    class RelevantSagaInfo
+    sealed class RelevantSagaInfo
     {
         public RelevantSagaInfo(ISagaData sagaData, IEnumerable<CorrelationProperty> correlationProperties, Saga saga)
         {

--- a/Rebus/Sagas/Saga.cs
+++ b/Rebus/Sagas/Saga.cs
@@ -126,7 +126,7 @@ public abstract class Saga<TSagaData> : Saga where TSagaData : ISagaData, new()
     {
     }
 
-    class CorrelationConfiguration : ICorrelationConfig<TSagaData>
+    sealed class CorrelationConfiguration : ICorrelationConfig<TSagaData>
     {
         readonly Type _sagaType;
 

--- a/Rebus/Sagas/SagaDataCorrelationProperties.cs
+++ b/Rebus/Sagas/SagaDataCorrelationProperties.cs
@@ -34,9 +34,9 @@ public class SagaDataCorrelationProperties : IEnumerable<CorrelationProperty>
 
         var messageType = body.GetType();
 
-        return _cachedCorrelationProperties.GetOrAdd(messageType, _ =>
+        return _cachedCorrelationProperties.GetOrAdd(messageType, nonCapturedMessageType =>
         {
-            var potentialCorrelationProperties = new[] { messageType }.Concat(messageType.GetBaseTypes())
+            var potentialCorrelationProperties = new[] { nonCapturedMessageType }.Concat(nonCapturedMessageType.GetBaseTypes())
                 .SelectMany(type => _correlationProperties.TryGetValue(type, out var potentialCorrelationproperties)
                     ? potentialCorrelationproperties
                     : Array.Empty<CorrelationProperty>())
@@ -45,7 +45,7 @@ public class SagaDataCorrelationProperties : IEnumerable<CorrelationProperty>
             if (!potentialCorrelationProperties.Any())
             {
                 throw new ArgumentException(
-                    $"Could not find any correlation properties for message {messageType} and saga data {_sagaDataType}");
+                    $"Could not find any correlation properties for message {nonCapturedMessageType} and saga data {_sagaDataType}");
             }
 
             return potentialCorrelationProperties;

--- a/Rebus/Serialization/Custom/CustomTypeNameConvention.cs
+++ b/Rebus/Serialization/Custom/CustomTypeNameConvention.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 namespace Rebus.Serialization.Custom;
 
-class CustomTypeNameConvention : IMessageTypeNameConvention
+sealed class CustomTypeNameConvention : IMessageTypeNameConvention
 {
     static string CodeExample(Type type = null, string name = null)
     {

--- a/Rebus/Serialization/Json/JsonSerializer.cs
+++ b/Rebus/Serialization/Json/JsonSerializer.cs
@@ -15,7 +15,7 @@ namespace Rebus.Serialization.Json;
 /// (i.e. full type info is included in the serialized format in order to support deserializing "unknown" types like
 /// implementations of interfaces, etc)
 /// </summary>
-class JsonSerializer : ISerializer
+sealed class JsonSerializer : ISerializer
 {
     /// <summary>
     /// Proper content type when a message has been serialized with this serializer (or another compatible JSON serializer) and it uses the standard UTF8 encoding

--- a/Rebus/Serialization/SimpleAssemblyQualifiedMessageTypeNameConvention.cs
+++ b/Rebus/Serialization/SimpleAssemblyQualifiedMessageTypeNameConvention.cs
@@ -4,7 +4,7 @@ using Rebus.Extensions;
 
 namespace Rebus.Serialization;
 
-class SimpleAssemblyQualifiedMessageTypeNameConvention : IMessageTypeNameConvention
+sealed class SimpleAssemblyQualifiedMessageTypeNameConvention : IMessageTypeNameConvention
 {
     readonly ConcurrentDictionary<Type, string> _typeToName = new ConcurrentDictionary<Type, string>();
     readonly ConcurrentDictionary<string, Type> _nameToType = new ConcurrentDictionary<string, Type>();

--- a/Rebus/Serialization/SimpleAssemblyQualifiedMessageTypeNameConvention.cs
+++ b/Rebus/Serialization/SimpleAssemblyQualifiedMessageTypeNameConvention.cs
@@ -9,7 +9,7 @@ sealed class SimpleAssemblyQualifiedMessageTypeNameConvention : IMessageTypeName
     readonly ConcurrentDictionary<Type, string> _typeToName = new ConcurrentDictionary<Type, string>();
     readonly ConcurrentDictionary<string, Type> _nameToType = new ConcurrentDictionary<string, Type>();
 
-    public string GetTypeName(Type type) => _typeToName.GetOrAdd(type, _ => type.GetSimpleAssemblyQualifiedName());
+    public string GetTypeName(Type type) => _typeToName.GetOrAdd(type, nonCapturedType => nonCapturedType.GetSimpleAssemblyQualifiedName());
 
-    public Type GetType(string name) => _nameToType.GetOrAdd(name, _ => Type.GetType(name));
+    public Type GetType(string name) => _nameToType.GetOrAdd(name, Type.GetType);
 }

--- a/Rebus/Threading/AsyncBottleneck.cs
+++ b/Rebus/Threading/AsyncBottleneck.cs
@@ -28,7 +28,7 @@ public class AsyncBottleneck
         return new Releaser(_semaphore);
     }
 
-    class Releaser : IDisposable
+    sealed class Releaser : IDisposable
     {
         readonly SemaphoreSlim _semaphore;
 

--- a/Rebus/Timeouts/ThrowingTimeoutManager.cs
+++ b/Rebus/Timeouts/ThrowingTimeoutManager.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace Rebus.Timeouts;
 
-class ThrowingTimeoutManager : ITimeoutManager
+sealed class ThrowingTimeoutManager : ITimeoutManager
 {
     public async Task Defer(DateTimeOffset approximateDueTime, Dictionary<string, string> headers, byte[] body)
     {

--- a/Rebus/Transport/FileSystem/FileSystemTransport.cs
+++ b/Rebus/Transport/FileSystem/FileSystemTransport.cs
@@ -187,7 +187,7 @@ public class FileSystemTransport : AbstractRebusTransport, IInitializable, ITran
         }
     }
 
-    class IncomingMessage : IDisposable
+    sealed class IncomingMessage : IDisposable
     {
         readonly FileStream _source;
         readonly string _filePath;
@@ -231,7 +231,7 @@ public class FileSystemTransport : AbstractRebusTransport, IInitializable, ITran
         }
     }
 
-    class Envelope
+    sealed class Envelope
     {
         public Dictionary<string, string> Headers { get; }
         public byte[] Body { get; }

--- a/Rebus/Transport/InMem/InMemNetwork.cs
+++ b/Rebus/Transport/InMem/InMemNetwork.cs
@@ -186,10 +186,8 @@ public class InMemNetwork
 
     static bool MessageIsExpired(InMemTransportMessage message)
     {
-        var headers = message.Headers;
-        if (!headers.ContainsKey(Headers.TimeToBeReceived)) return false;
+        if (!message.Headers.TryGetValue(Headers.TimeToBeReceived, out var timeToBeReceived)) return false;
 
-        var timeToBeReceived = headers[Headers.TimeToBeReceived];
         var maximumAge = TimeSpan.Parse(timeToBeReceived);
 
         return message.Age > maximumAge;

--- a/Rebus/Transport/TransactionContextWithOwningBus.cs
+++ b/Rebus/Transport/TransactionContextWithOwningBus.cs
@@ -3,7 +3,7 @@ using Rebus.Bus;
 
 namespace Rebus.Transport;
 
-class TransactionContextWithOwningBus : TransactionContext, ITransactionContextWithOwningBus
+sealed class TransactionContextWithOwningBus : TransactionContext, ITransactionContextWithOwningBus
 {
     public TransactionContextWithOwningBus(RebusBus owningBus)
     {

--- a/Rebus/Workers/ThreadPoolBased/DefaultBackoffStrategy.cs
+++ b/Rebus/Workers/ThreadPoolBased/DefaultBackoffStrategy.cs
@@ -7,7 +7,7 @@ using Rebus.Config;
 
 namespace Rebus.Workers.ThreadPoolBased;
 
-class DefaultBackoffStrategy : IBackoffStrategy
+sealed class DefaultBackoffStrategy : IBackoffStrategy
 {
     readonly TimeSpan[] _backoffTimes;
     readonly Options _options;

--- a/Rebus/Workers/ThreadPoolBased/ThreadPoolWorker.cs
+++ b/Rebus/Workers/ThreadPoolBased/ThreadPoolWorker.cs
@@ -12,7 +12,7 @@ using Rebus.Transport;
 
 namespace Rebus.Workers.ThreadPoolBased;
 
-class ThreadPoolWorker : IWorker
+sealed class ThreadPoolWorker : IWorker
 {
     readonly CancellationTokenSource _cancellationTokenSource = new();
     readonly ParallelOperationsManager _parallelOperationsManager;

--- a/Rebus/Workers/TplBased/TplWorker.cs
+++ b/Rebus/Workers/TplBased/TplWorker.cs
@@ -12,7 +12,7 @@ using Rebus.Workers.ThreadPoolBased;
 
 namespace Rebus.Workers.TplBased;
 
-class TplWorker : IWorker
+sealed class TplWorker : IWorker
 {
     readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
     readonly ManualResetEvent _workerStopped = new ManualResetEvent(false);


### PR DESCRIPTION
- Avoid a string allocation when deserializing UTF8
- Avoid capturing variables
- Avoid double dictionary lookups
- Reduce LINQ usage
- Made non-public classes sealed

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
