### PR TITLE
Fix typo in RebusConfigurer comments

### DIFF
--- a/Rebus/Config/RebusConfigurer.cs
+++ b/Rebus/Config/RebusConfigurer.cs
@@ -87,7 +87,7 @@ public class RebusConfigurer
 
     /// <summary>
     /// Configures how Rebus tracks <see cref="Exception"/>s.
-    /// Defaults to tracking exceptions in memory. Trasking errors in memory is easy and does not require any additional configuration,
+    /// Defaults to tracking exceptions in memory. Tracking errors in memory is easy and does not require any additional configuration,
     /// but it can lead to excessive retrying in competing consumer scenarios, because each node will count delivery attempts individually.
     /// It is recommended in most cases to configure some kind of distributed error tracker when running distributed consumers.
     /// </summary>


### PR DESCRIPTION
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
