### PR TITLE
Fix typo in XML documentation comment

### DIFF
--- a/Rebus/Sagas/Idempotent/IdempotencyData.cs
+++ b/Rebus/Sagas/Idempotent/IdempotencyData.cs
@@ -34,7 +34,7 @@ public class IdempotencyData
     public List<OutgoingMessages> OutgoingMessages { get; } = new List<OutgoingMessages>();
 
     /// <summary>
-    /// Getst the IDs of all messages that have been handled
+    /// Gets the IDs of all messages that have been handled
     /// </summary>
     public HashSet<string> HandledMessageIds { get; } = new HashSet<string>();
 


### PR DESCRIPTION
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
